### PR TITLE
Phase 1 — Git & GitHub Integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,9 @@
 # Required scopes: repo, issues, pull_requests
 GITHUB_TOKEN=
 
+# GitHub repository coordinates used by GitHubService
+GITHUB_OWNER=
+GITHUB_REPO=
+
 # Shared secret for authenticating remote agent bridge connections
 NEXUS_BRIDGE_SECRET=

--- a/src/git/GitService.test.ts
+++ b/src/git/GitService.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock simple-git BEFORE importing GitService
+// ---------------------------------------------------------------------------
+
+const { mockGit } = vi.hoisted(() => {
+  const mockGit = {
+    status: vi.fn(),
+    log: vi.fn(),
+    checkoutLocalBranch: vi.fn(),
+    getRemotes: vi.fn(),
+  };
+  return { mockGit };
+});
+
+vi.mock('simple-git', () => ({
+  default: vi.fn(() => mockGit),
+}));
+
+// Mock the logger so file I/O doesn't happen during tests
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+// Mock fs so detectSubRepos doesn't touch the real filesystem
+vi.mock('fs', () => ({
+  readdirSync: vi.fn(() => []),
+  statSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+import { GitService, GitServiceError } from './GitService.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface FakeStatus {
+  current: string | null;
+  ahead: number;
+  behind: number;
+  modified: string[];
+  not_added: string[];
+  staged: string[];
+  deleted: string[];
+  isClean: () => boolean;
+}
+
+function makeStatus(overrides: Partial<FakeStatus> = {}): FakeStatus {
+  return {
+    current: overrides.current ?? 'main',
+    ahead: overrides.ahead ?? 0,
+    behind: overrides.behind ?? 0,
+    modified: overrides.modified ?? [],
+    not_added: overrides.not_added ?? [],
+    staged: overrides.staged ?? [],
+    deleted: overrides.deleted ?? [],
+    isClean: overrides.isClean ?? ((): boolean => true),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GitService', () => {
+  let service: GitService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new GitService('/fake/workdir');
+  });
+
+  // ---- getCurrentBranch ---------------------------------------------------
+
+  describe('getCurrentBranch', () => {
+    it('returns the branch name from git status', async () => {
+      mockGit.status.mockResolvedValue(makeStatus({ current: 'feat/my-feature' }));
+
+      const branch = await service.getCurrentBranch();
+
+      expect(branch).toBe('feat/my-feature');
+    });
+
+    it("returns 'HEAD' when current branch is null (detached HEAD)", async () => {
+      // Bypass makeStatus because null is treated as nullish by ??, which would
+      // substitute the default 'main'. Set current: null directly on the mock.
+      mockGit.status.mockResolvedValue({
+        current: null,
+        ahead: 0,
+        behind: 0,
+        modified: [],
+        not_added: [],
+        staged: [],
+        deleted: [],
+        isClean: () => true,
+      });
+
+      const branch = await service.getCurrentBranch();
+
+      expect(branch).toBe('HEAD');
+    });
+
+    it('throws GitServiceError when git status fails', async () => {
+      mockGit.status.mockRejectedValue(new Error('not a git repo'));
+
+      await expect(service.getCurrentBranch()).rejects.toThrow(GitServiceError);
+    });
+  });
+
+  // ---- getStatus ----------------------------------------------------------
+
+  describe('getStatus', () => {
+    it('returns a clean status snapshot', async () => {
+      mockGit.status.mockResolvedValue(
+        makeStatus({ current: 'main', isClean: () => true })
+      );
+
+      const status = await service.getStatus();
+
+      expect(status.branch).toBe('main');
+      expect(status.isDirty).toBe(false);
+      expect(status.modified).toEqual([]);
+    });
+
+    it('reflects dirty state when modified files are present', async () => {
+      mockGit.status.mockResolvedValue(
+        makeStatus({
+          current: 'fix/auth',
+          modified: ['src/auth.ts', 'src/api.ts'],
+          not_added: ['src/new.ts'],
+          isClean: () => false,
+        })
+      );
+
+      const status = await service.getStatus();
+
+      expect(status.isDirty).toBe(true);
+      expect(status.modified).toEqual(['src/auth.ts', 'src/api.ts']);
+      expect(status.untracked).toEqual(['src/new.ts']);
+    });
+
+    it('includes staged and deleted files', async () => {
+      mockGit.status.mockResolvedValue(
+        makeStatus({
+          staged: ['src/staged.ts'],
+          deleted: ['src/old.ts'],
+          isClean: () => false,
+        })
+      );
+
+      const status = await service.getStatus();
+
+      expect(status.staged).toContain('src/staged.ts');
+      expect(status.deleted).toContain('src/old.ts');
+    });
+
+    it('throws GitServiceError on failure', async () => {
+      mockGit.status.mockRejectedValue(new Error('git error'));
+
+      await expect(service.getStatus()).rejects.toThrow(GitServiceError);
+    });
+  });
+
+  // ---- getAheadBehind -----------------------------------------------------
+
+  describe('getAheadBehind', () => {
+    it('returns ahead and behind counts from status', async () => {
+      mockGit.status.mockResolvedValue(makeStatus({ ahead: 3, behind: 1 }));
+
+      const result = await service.getAheadBehind();
+
+      expect(result.ahead).toBe(3);
+      expect(result.behind).toBe(1);
+    });
+
+    it('returns zeros when branch is in sync with remote', async () => {
+      mockGit.status.mockResolvedValue(makeStatus({ ahead: 0, behind: 0 }));
+
+      const result = await service.getAheadBehind();
+
+      expect(result).toEqual({ ahead: 0, behind: 0 });
+    });
+
+    it('throws GitServiceError on failure', async () => {
+      mockGit.status.mockRejectedValue(new Error('git error'));
+
+      await expect(service.getAheadBehind()).rejects.toThrow(GitServiceError);
+    });
+  });
+
+  // ---- getRecentCommits ---------------------------------------------------
+
+  describe('getRecentCommits', () => {
+    const rawLogEntries = [
+      {
+        hash: 'abc1234567890',
+        date: '2026-03-28',
+        message: 'feat: add feature',
+        author_name: 'Alice',
+      },
+      {
+        hash: 'def9876543210',
+        date: '2026-03-27',
+        message: 'fix: patch bug',
+        author_name: 'Bob',
+      },
+    ];
+
+    it('returns mapped commits with short hashes', async () => {
+      mockGit.log.mockResolvedValue({ all: rawLogEntries });
+
+      const commits = await service.getRecentCommits(5);
+
+      expect(commits).toHaveLength(2);
+      expect(commits[0]?.hash).toBe('abc1234');
+      expect(commits[0]?.message).toBe('feat: add feature');
+      expect(commits[0]?.author).toBe('Alice');
+    });
+
+    it('passes maxCount to simple-git log', async () => {
+      mockGit.log.mockResolvedValue({ all: [] });
+
+      await service.getRecentCommits(10);
+
+      expect(mockGit.log).toHaveBeenCalledWith({ maxCount: 10 });
+    });
+
+    it('throws GitServiceError when log fails', async () => {
+      mockGit.log.mockRejectedValue(new Error('git error'));
+
+      await expect(service.getRecentCommits(5)).rejects.toThrow(GitServiceError);
+    });
+  });
+
+  // ---- createBranch -------------------------------------------------------
+
+  describe('createBranch', () => {
+    it('calls checkoutLocalBranch with the given name', async () => {
+      mockGit.checkoutLocalBranch.mockResolvedValue(undefined);
+
+      await service.createBranch('nexus/task-42-fix-auth');
+
+      expect(mockGit.checkoutLocalBranch).toHaveBeenCalledWith('nexus/task-42-fix-auth');
+    });
+
+    it('throws GitServiceError when checkout fails', async () => {
+      mockGit.checkoutLocalBranch.mockRejectedValue(new Error('branch exists'));
+
+      await expect(service.createBranch('duplicate-branch')).rejects.toThrow(GitServiceError);
+    });
+  });
+
+  // ---- GitServiceError ----------------------------------------------------
+
+  describe('GitServiceError', () => {
+    it('has the correct name and preserves message', () => {
+      const err = new GitServiceError('something went wrong', new Error('cause'));
+
+      expect(err.name).toBe('GitServiceError');
+      expect(err.message).toBe('something went wrong');
+      expect(err instanceof Error).toBe(true);
+    });
+  });
+});

--- a/src/git/GitService.ts
+++ b/src/git/GitService.ts
@@ -1,0 +1,202 @@
+import simpleGit, { type SimpleGit } from 'simple-git';
+import { readdirSync, statSync, type Dirent } from 'fs';
+import { join, relative } from 'path';
+import { logger } from '../utils/logger.js';
+import type { GitStatus, Commit, SubRepo } from '../types.js';
+
+/**
+ * Reads the entries of `dir`, returning `null` instead of throwing when the
+ * path is inaccessible. Typed as a helper so the correct `Dirent[]` overload
+ * is inferred rather than the widest `readdirSync` return type.
+ */
+function tryReaddir(dir: string): Dirent[] | null {
+  try {
+    return readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+}
+
+/** Maximum directory depth searched when detecting sub-repositories. */
+const MAX_SUBREPO_DEPTH = 3;
+
+/** Directory names that are always skipped during sub-repo detection. */
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', '.cache', 'coverage', '.nyc_output']);
+
+/**
+ * Thrown when a git operation fails due to an unexpected error.
+ */
+export class GitServiceError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'GitServiceError';
+  }
+}
+
+/**
+ * Provides programmatic access to git operations for a single repository.
+ * All methods operate on the `workdir` supplied at construction time.
+ */
+export class GitService {
+  private readonly git: SimpleGit;
+  private readonly workdir: string;
+
+  /**
+   * @param workdir - Absolute path to the git repository root. Defaults to `process.cwd()`.
+   */
+  constructor(workdir: string = process.cwd()) {
+    this.workdir = workdir;
+    this.git = simpleGit(workdir);
+  }
+
+  /**
+   * Returns the name of the currently checked-out branch.
+   *
+   * @returns Branch name, or `'HEAD'` when in detached HEAD state.
+   * @throws {GitServiceError} If the git command fails.
+   */
+  async getCurrentBranch(): Promise<string> {
+    try {
+      const status = await this.git.status();
+      return status.current ?? 'HEAD';
+    } catch (err) {
+      throw new GitServiceError('Failed to get current branch', err);
+    }
+  }
+
+  /**
+   * Returns a snapshot of the current working tree status.
+   *
+   * @returns {@link GitStatus} with branch name, dirty flag, and categorised file lists.
+   * @throws {GitServiceError} If the git command fails.
+   */
+  async getStatus(): Promise<GitStatus> {
+    try {
+      const status = await this.git.status();
+      return {
+        branch: status.current ?? 'HEAD',
+        isDirty: !status.isClean(),
+        modified: status.modified,
+        untracked: status.not_added,
+        staged: status.staged,
+        deleted: status.deleted,
+      };
+    } catch (err) {
+      throw new GitServiceError('Failed to get git status', err);
+    }
+  }
+
+  /**
+   * Returns how many commits the local branch is ahead of and behind its remote tracking branch.
+   *
+   * @returns Object with `ahead` and `behind` counts. Both are `0` when no tracking branch exists.
+   * @throws {GitServiceError} If the git command fails.
+   */
+  async getAheadBehind(): Promise<{ ahead: number; behind: number }> {
+    try {
+      const status = await this.git.status();
+      return { ahead: status.ahead, behind: status.behind };
+    } catch (err) {
+      throw new GitServiceError('Failed to get ahead/behind counts', err);
+    }
+  }
+
+  /**
+   * Returns the `n` most recent commits on the current branch.
+   *
+   * @param n - Maximum number of commits to return (must be ≥ 1).
+   * @returns Array of {@link Commit} objects, newest first.
+   * @throws {GitServiceError} If the git command fails.
+   */
+  async getRecentCommits(n: number): Promise<Commit[]> {
+    try {
+      const log = await this.git.log({ maxCount: n });
+      return log.all.map((entry) => ({
+        hash: entry.hash.slice(0, 7),
+        date: entry.date,
+        message: entry.message,
+        author: entry.author_name,
+      }));
+    } catch (err) {
+      throw new GitServiceError('Failed to get recent commits', err);
+    }
+  }
+
+  /**
+   * Recursively walks `rootPath` looking for nested git repositories.
+   * Skips `node_modules`, `dist`, and other common non-source directories.
+   * Searches up to {@link MAX_SUBREPO_DEPTH} levels deep.
+   *
+   * @param rootPath - Absolute path of the workspace root to search within.
+   * @returns Array of detected {@link SubRepo} entries.
+   */
+  async detectSubRepos(rootPath: string): Promise<SubRepo[]> {
+    const subRepos: SubRepo[] = [];
+
+    const walk = async (dir: string, depth: number): Promise<void> => {
+      if (depth > MAX_SUBREPO_DEPTH) return;
+
+      const entries = tryReaddir(dir);
+      if (!entries) return;
+
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (SKIP_DIRS.has(entry.name)) continue;
+
+        const fullPath = join(dir, entry.name);
+
+        // Skip the root repo itself (depth === 0 means we're scanning rootPath's children).
+        const isSubRepoRoot = ((): boolean => {
+          try {
+            statSync(join(fullPath, '.git'));
+            return true;
+          } catch {
+            return false;
+          }
+        })();
+
+        if (isSubRepoRoot) {
+          try {
+            const subGit = simpleGit(fullPath);
+            const status = await subGit.status();
+            const remote = await subGit
+              .getRemotes(true)
+              .then((remotes) => remotes[0]?.refs.fetch)
+              .catch(() => undefined);
+
+            subRepos.push({
+              name: entry.name,
+              path: relative(rootPath, fullPath),
+              remote,
+              branch: status.current ?? undefined,
+              isDirty: !status.isClean(),
+            });
+          } catch (err) {
+            logger.warn({ path: fullPath, err }, 'Failed to inspect sub-repo, skipping');
+          }
+          // Don't recurse further into a sub-repo's contents.
+        } else {
+          await walk(fullPath, depth + 1);
+        }
+      }
+    };
+
+    await walk(rootPath, 0);
+    return subRepos;
+  }
+
+  /**
+   * Creates a new local branch and switches to it.
+   *
+   * @param name - The branch name to create (e.g. `nexus/task-42-fix-auth`).
+   * @throws {GitServiceError} If the branch already exists or the git command fails.
+   */
+  async createBranch(name: string): Promise<void> {
+    try {
+      await this.git.checkoutLocalBranch(name);
+      logger.info({ branch: name, workdir: this.workdir }, 'Created and checked out branch');
+    } catch (err) {
+      throw new GitServiceError(`Failed to create branch '${name}'`, err);
+    }
+  }
+}

--- a/src/github/GitHubService.test.ts
+++ b/src/github/GitHubService.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock @octokit/rest BEFORE importing GitHubService
+// ---------------------------------------------------------------------------
+
+const { mockRest } = vi.hoisted(() => {
+  const mockRest = {
+    issues: {
+      listForRepo: vi.fn(),
+      create: vi.fn(),
+      createComment: vi.fn(),
+    },
+    pulls: {
+      create: vi.fn(),
+      get: vi.fn(),
+    },
+    repos: {
+      listCollaborators: vi.fn(),
+    },
+  };
+  return { mockRest };
+});
+
+vi.mock('@octokit/rest', () => ({
+  Octokit: vi.fn(() => ({ rest: mockRest })),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+import { GitHubService, GitHubServiceError } from './GitHubService.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_CONFIG = { token: 'ghp_test', owner: 'acme', repo: 'widget' };
+
+interface RawIssue {
+  number: number;
+  title: string;
+  body: string;
+  state: string;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  labels: { name: string }[];
+  assignee: { login: string } | null;
+  pull_request: unknown;
+}
+
+function makeRawIssue(overrides: Partial<RawIssue> = {}): RawIssue {
+  return {
+    number: overrides.number ?? 1,
+    title: overrides.title ?? 'Test issue',
+    body: overrides.body ?? 'Body text',
+    state: overrides.state ?? 'open',
+    html_url: overrides.html_url ?? 'https://github.com/acme/widget/issues/1',
+    created_at: overrides.created_at ?? '2026-01-01T00:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-01-02T00:00:00Z',
+    labels: overrides.labels ?? [],
+    assignee: overrides.assignee ?? null,
+    pull_request: overrides.pull_request,
+  };
+}
+
+interface RawPR {
+  number: number;
+  title: string;
+  html_url: string;
+  state: string;
+  draft: boolean;
+  merged_at: string | null;
+  head: { ref: string };
+  base: { ref: string };
+  created_at: string;
+  updated_at: string;
+}
+
+function makeRawPR(overrides: Partial<RawPR> = {}): RawPR {
+  return {
+    number: overrides.number ?? 10,
+    title: overrides.title ?? 'Test PR',
+    html_url: overrides.html_url ?? 'https://github.com/acme/widget/pull/10',
+    state: overrides.state ?? 'open',
+    draft: overrides.draft ?? false,
+    merged_at: overrides.merged_at ?? null,
+    head: overrides.head ?? { ref: 'feat/branch' },
+    base: overrides.base ?? { ref: 'main' },
+    created_at: overrides.created_at ?? '2026-01-01T00:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-01-02T00:00:00Z',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GitHubService', () => {
+  let service: GitHubService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new GitHubService(BASE_CONFIG);
+  });
+
+  // ---- getIssues ----------------------------------------------------------
+
+  describe('getIssues', () => {
+    it('returns mapped open issues', async () => {
+      const raw = makeRawIssue({
+        number: 42,
+        title: 'Fix auth bug',
+        labels: [{ name: 'bug' }],
+        assignee: { login: 'alice' },
+      });
+      mockRest.issues.listForRepo.mockResolvedValue({ data: [raw] });
+
+      const issues = await service.getIssues();
+
+      expect(issues).toHaveLength(1);
+      expect(issues[0]?.issueNumber).toBe(42);
+      expect(issues[0]?.title).toBe('Fix auth bug');
+      expect(issues[0]?.labels).toEqual(['bug']);
+      expect(issues[0]?.assigneeLogin).toBe('alice');
+    });
+
+    it('filters out pull requests from the response', async () => {
+      const pr = makeRawIssue({ number: 99, pull_request: { url: 'https://...' } });
+      const issue = makeRawIssue({ number: 1 });
+      mockRest.issues.listForRepo.mockResolvedValue({ data: [pr, issue] });
+
+      const issues = await service.getIssues();
+
+      expect(issues).toHaveLength(1);
+      expect(issues[0]?.issueNumber).toBe(1);
+    });
+
+    it('passes filters to Octokit', async () => {
+      mockRest.issues.listForRepo.mockResolvedValue({ data: [] });
+
+      await service.getIssues({ state: 'closed', labels: ['bug', 'urgent'], assignee: 'bob' });
+
+      expect(mockRest.issues.listForRepo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: 'closed',
+          labels: 'bug,urgent',
+          assignee: 'bob',
+        })
+      );
+    });
+
+    it('uses open state by default', async () => {
+      mockRest.issues.listForRepo.mockResolvedValue({ data: [] });
+
+      await service.getIssues();
+
+      expect(mockRest.issues.listForRepo).toHaveBeenCalledWith(
+        expect.objectContaining({ state: 'open' })
+      );
+    });
+
+    it('throws GitHubServiceError on API failure', async () => {
+      mockRest.issues.listForRepo.mockRejectedValue(
+        Object.assign(new Error('API error'), { status: 404 })
+      );
+
+      await expect(service.getIssues()).rejects.toThrow(GitHubServiceError);
+    });
+  });
+
+  // ---- createIssue --------------------------------------------------------
+
+  describe('createIssue', () => {
+    it('creates and returns a mapped issue', async () => {
+      const raw = makeRawIssue({ number: 5, title: 'New feature' });
+      mockRest.issues.create.mockResolvedValue({ data: raw });
+
+      const issue = await service.createIssue({ title: 'New feature', labels: ['enhancement'] });
+
+      expect(issue.issueNumber).toBe(5);
+      expect(issue.title).toBe('New feature');
+    });
+
+    it('passes all input fields to Octokit', async () => {
+      mockRest.issues.create.mockResolvedValue({ data: makeRawIssue() });
+
+      await service.createIssue({
+        title: 'Bug',
+        body: 'Description',
+        labels: ['bug'],
+        assignees: ['alice'],
+      });
+
+      expect(mockRest.issues.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Bug',
+          body: 'Description',
+          labels: ['bug'],
+          assignees: ['alice'],
+        })
+      );
+    });
+
+    it('throws GitHubServiceError on API failure', async () => {
+      mockRest.issues.create.mockRejectedValue(new Error('Validation failed'));
+
+      await expect(service.createIssue({ title: 'X' })).rejects.toThrow(GitHubServiceError);
+    });
+  });
+
+  // ---- createPR -----------------------------------------------------------
+
+  describe('createPR', () => {
+    it('creates and returns a mapped PR', async () => {
+      const raw = makeRawPR({ number: 77, title: 'feat: add oauth' });
+      mockRest.pulls.create.mockResolvedValue({ data: raw });
+
+      const pr = await service.createPR({
+        title: 'feat: add oauth',
+        head: 'feat/oauth',
+        base: 'main',
+      });
+
+      expect(pr.prNumber).toBe(77);
+      expect(pr.title).toBe('feat: add oauth');
+      expect(pr.status).toBe('open');
+    });
+
+    it('resolves merged status when merged_at is set', async () => {
+      const raw = makeRawPR({
+        state: 'closed',
+        merged_at: '2026-03-01T00:00:00Z',
+      });
+      mockRest.pulls.create.mockResolvedValue({ data: raw });
+
+      const pr = await service.createPR({ title: 'X', head: 'feat/x', base: 'main' });
+
+      expect(pr.status).toBe('merged');
+    });
+
+    it('resolves draft status', async () => {
+      const raw = makeRawPR({ draft: true });
+      mockRest.pulls.create.mockResolvedValue({ data: raw });
+
+      const pr = await service.createPR({ title: 'X', head: 'feat/x', base: 'main' });
+
+      expect(pr.status).toBe('draft');
+    });
+
+    it('throws GitHubServiceError on API failure', async () => {
+      mockRest.pulls.create.mockRejectedValue(new Error('Conflict'));
+
+      await expect(
+        service.createPR({ title: 'X', head: 'feat/x', base: 'main' })
+      ).rejects.toThrow(GitHubServiceError);
+    });
+  });
+
+  // ---- getPRStatus --------------------------------------------------------
+
+  describe('getPRStatus', () => {
+    it('fetches and returns the PR status', async () => {
+      const raw = makeRawPR({ number: 42, state: 'open' });
+      mockRest.pulls.get.mockResolvedValue({ data: raw });
+
+      const pr = await service.getPRStatus(42);
+
+      expect(pr.prNumber).toBe(42);
+      expect(pr.status).toBe('open');
+    });
+
+    it('passes the pull_number to Octokit', async () => {
+      mockRest.pulls.get.mockResolvedValue({ data: makeRawPR() });
+
+      await service.getPRStatus(55);
+
+      expect(mockRest.pulls.get).toHaveBeenCalledWith(
+        expect.objectContaining({ pull_number: 55 })
+      );
+    });
+
+    it('throws GitHubServiceError when the PR is not found', async () => {
+      mockRest.pulls.get.mockRejectedValue(Object.assign(new Error('Not Found'), { status: 404 }));
+
+      await expect(service.getPRStatus(999)).rejects.toThrow(GitHubServiceError);
+    });
+  });
+
+  // ---- getCollaborators ---------------------------------------------------
+
+  describe('getCollaborators', () => {
+    it('returns mapped contributors', async () => {
+      mockRest.repos.listCollaborators.mockResolvedValue({
+        data: [
+          { login: 'alice', name: 'Alice A', avatar_url: 'https://img/alice', permissions: { admin: true } },
+          { login: 'bob', name: 'Bob B', avatar_url: 'https://img/bob', permissions: { push: true } },
+          { login: 'carol', name: 'Carol', avatar_url: 'https://img/carol', permissions: { pull: true } },
+        ],
+      });
+
+      const contributors = await service.getCollaborators();
+
+      expect(contributors).toHaveLength(3);
+      expect(contributors[0]?.role).toBe('owner');
+      expect(contributors[1]?.role).toBe('maintainer');
+      expect(contributors[2]?.role).toBe('contributor');
+    });
+
+    it('throws GitHubServiceError on permission error', async () => {
+      mockRest.repos.listCollaborators.mockRejectedValue(
+        Object.assign(new Error('Forbidden'), { status: 403 })
+      );
+
+      await expect(service.getCollaborators()).rejects.toThrow(GitHubServiceError);
+    });
+  });
+
+  // ---- addComment ---------------------------------------------------------
+
+  describe('addComment', () => {
+    it('calls Octokit with the correct issue number and body', async () => {
+      mockRest.issues.createComment.mockResolvedValue({ data: {} });
+
+      await service.addComment(42, 'PR opened: https://github.com/acme/widget/pull/10');
+
+      expect(mockRest.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          issue_number: 42,
+          body: 'PR opened: https://github.com/acme/widget/pull/10',
+        })
+      );
+    });
+
+    it('throws GitHubServiceError on API failure', async () => {
+      mockRest.issues.createComment.mockRejectedValue(new Error('Forbidden'));
+
+      await expect(service.addComment(1, 'hello')).rejects.toThrow(GitHubServiceError);
+    });
+  });
+
+  // ---- GitHubServiceError -------------------------------------------------
+
+  describe('GitHubServiceError', () => {
+    it('carries statusCode and is an instance of Error', () => {
+      const err = new GitHubServiceError('Not found', 404);
+
+      expect(err.name).toBe('GitHubServiceError');
+      expect(err.statusCode).toBe(404);
+      expect(err instanceof Error).toBe(true);
+    });
+  });
+});

--- a/src/github/GitHubService.ts
+++ b/src/github/GitHubService.ts
@@ -1,0 +1,278 @@
+import { Octokit } from '@octokit/rest';
+import { logger } from '../utils/logger.js';
+import type {
+  Issue,
+  IssueFilters,
+  CreateIssueInput,
+  PR,
+  CreatePRInput,
+  PRStatus,
+  Contributor,
+} from '../types.js';
+
+/** Configuration required to construct a {@link GitHubService}. */
+export interface GitHubServiceConfig {
+  /** GitHub personal access token with `repo`, `issues`, and `pull_requests` scopes. */
+  token: string;
+  /** Repository owner (user or organisation login). */
+  owner: string;
+  /** Repository name. */
+  repo: string;
+}
+
+/**
+ * Thrown when a GitHub API call fails.
+ */
+export class GitHubServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'GitHubServiceError';
+  }
+}
+
+/**
+ * Maps the raw `state` / `draft` / `merged_at` fields from the Octokit pull
+ * response to the {@link PRStatus} union used internally by NEXUS.
+ */
+function resolvePRStatus(
+  state: string,
+  draft: boolean | undefined,
+  mergedAt: string | null | undefined
+): PRStatus {
+  if (draft) return 'draft';
+  if (mergedAt) return 'merged';
+  if (state === 'closed') return 'closed';
+  return 'open';
+}
+
+/**
+ * Wraps the GitHub REST API (via Octokit) for all repository operations
+ * that NEXUS performs — issues, pull requests, collaborators, and comments.
+ */
+export class GitHubService {
+  private readonly octokit: Octokit;
+  private readonly owner: string;
+  private readonly repo: string;
+
+  /**
+   * @param config - Authentication token plus owner/repo coordinates.
+   */
+  constructor(config: GitHubServiceConfig) {
+    this.owner = config.owner;
+    this.repo = config.repo;
+    this.octokit = new Octokit({ auth: config.token });
+  }
+
+  /**
+   * Lists issues in the configured repository.
+   *
+   * @param filters - Optional filters for state, labels, and assignee.
+   * @returns Array of {@link Issue} objects sorted newest-first.
+   * @throws {GitHubServiceError} If the API call fails.
+   */
+  async getIssues(filters?: IssueFilters): Promise<Issue[]> {
+    try {
+      const { data } = await this.octokit.rest.issues.listForRepo({
+        owner: this.owner,
+        repo: this.repo,
+        state: filters?.state ?? 'open',
+        labels: filters?.labels?.join(','),
+        assignee: filters?.assignee,
+        per_page: 50,
+      });
+
+      // The issues API also returns pull requests; exclude them.
+      return data
+        .filter((item) => !item.pull_request)
+        .map((item) => ({
+          issueNumber: item.number,
+          title: item.title,
+          body: item.body ?? '',
+          labels: item.labels.map((l) => (typeof l === 'string' ? l : (l.name ?? ''))),
+          assigneeLogin: item.assignee?.login,
+          url: item.html_url,
+          state: item.state as 'open' | 'closed',
+          createdAt: new Date(item.created_at),
+          updatedAt: new Date(item.updated_at),
+        }));
+    } catch (err) {
+      const statusCode = (err as { status?: number }).status;
+      logger.error({ owner: this.owner, repo: this.repo, err }, 'getIssues failed');
+      throw new GitHubServiceError('Failed to list issues', statusCode, err);
+    }
+  }
+
+  /**
+   * Creates a new issue in the configured repository.
+   *
+   * @param input - Issue title, body, labels, and optional assignees.
+   * @returns The newly created {@link Issue}.
+   * @throws {GitHubServiceError} If the API call fails.
+   */
+  async createIssue(input: CreateIssueInput): Promise<Issue> {
+    try {
+      const { data } = await this.octokit.rest.issues.create({
+        owner: this.owner,
+        repo: this.repo,
+        title: input.title,
+        body: input.body,
+        labels: input.labels,
+        assignees: input.assignees,
+      });
+
+      return {
+        issueNumber: data.number,
+        title: data.title,
+        body: data.body ?? '',
+        labels: data.labels.map((l) => (typeof l === 'string' ? l : (l.name ?? ''))),
+        assigneeLogin: data.assignee?.login,
+        url: data.html_url,
+        state: data.state as 'open' | 'closed',
+        createdAt: new Date(data.created_at),
+        updatedAt: new Date(data.updated_at),
+      };
+    } catch (err) {
+      const statusCode = (err as { status?: number }).status;
+      logger.error({ title: input.title, err }, 'createIssue failed');
+      throw new GitHubServiceError('Failed to create issue', statusCode, err);
+    }
+  }
+
+  /**
+   * Opens a pull request in the configured repository.
+   *
+   * @param input - PR title, body, head branch, and base branch.
+   * @returns The newly created {@link PR}.
+   * @throws {GitHubServiceError} If the API call fails.
+   */
+  async createPR(input: CreatePRInput): Promise<PR> {
+    try {
+      const { data } = await this.octokit.rest.pulls.create({
+        owner: this.owner,
+        repo: this.repo,
+        title: input.title,
+        body: input.body,
+        head: input.head,
+        base: input.base,
+      });
+
+      return {
+        prNumber: data.number,
+        title: data.title,
+        url: data.html_url,
+        status: resolvePRStatus(data.state, data.draft, data.merged_at),
+        head: data.head.ref,
+        base: data.base.ref,
+        createdAt: new Date(data.created_at),
+        updatedAt: new Date(data.updated_at),
+      };
+    } catch (err) {
+      const statusCode = (err as { status?: number }).status;
+      logger.error({ head: input.head, base: input.base, err }, 'createPR failed');
+      throw new GitHubServiceError('Failed to create pull request', statusCode, err);
+    }
+  }
+
+  /**
+   * Fetches the current status of a pull request by number.
+   *
+   * @param prNumber - The pull request number.
+   * @returns The {@link PR} with its resolved {@link PRStatus}.
+   * @throws {GitHubServiceError} If the PR does not exist or the API call fails.
+   */
+  async getPRStatus(prNumber: number): Promise<PR> {
+    try {
+      const { data } = await this.octokit.rest.pulls.get({
+        owner: this.owner,
+        repo: this.repo,
+        pull_number: prNumber,
+      });
+
+      return {
+        prNumber: data.number,
+        title: data.title,
+        url: data.html_url,
+        status: resolvePRStatus(data.state, data.draft, data.merged_at),
+        head: data.head.ref,
+        base: data.base.ref,
+        createdAt: new Date(data.created_at),
+        updatedAt: new Date(data.updated_at),
+      };
+    } catch (err) {
+      const statusCode = (err as { status?: number }).status;
+      logger.error({ prNumber, err }, 'getPRStatus failed');
+      throw new GitHubServiceError(`Failed to get PR #${prNumber}`, statusCode, err);
+    }
+  }
+
+  /**
+   * Lists repository collaborators.
+   *
+   * Requires the authenticated user to have at least push access to the repository.
+   *
+   * @returns Array of {@link Contributor} objects.
+   * @throws {GitHubServiceError} If the API call fails or the token lacks permission.
+   */
+  async getCollaborators(): Promise<Contributor[]> {
+    try {
+      const { data } = await this.octokit.rest.repos.listCollaborators({
+        owner: this.owner,
+        repo: this.repo,
+        per_page: 100,
+      });
+
+      return data.map((user) => ({
+        login: user.login,
+        name: user.name ?? undefined,
+        avatarUrl: user.avatar_url,
+        role: resolveRole(user.permissions),
+      }));
+    } catch (err) {
+      const statusCode = (err as { status?: number }).status;
+      logger.error({ owner: this.owner, repo: this.repo, err }, 'getCollaborators failed');
+      throw new GitHubServiceError('Failed to list collaborators', statusCode, err);
+    }
+  }
+
+  /**
+   * Posts a comment on an issue or pull request.
+   *
+   * @param issueNumber - The issue (or PR) number to comment on.
+   * @param body - Markdown body of the comment.
+   * @throws {GitHubServiceError} If the API call fails.
+   */
+  async addComment(issueNumber: number, body: string): Promise<void> {
+    try {
+      await this.octokit.rest.issues.createComment({
+        owner: this.owner,
+        repo: this.repo,
+        issue_number: issueNumber,
+        body,
+      });
+      logger.info({ issueNumber }, 'Posted comment on issue');
+    } catch (err) {
+      const statusCode = (err as { status?: number }).status;
+      logger.error({ issueNumber, err }, 'addComment failed');
+      throw new GitHubServiceError(`Failed to comment on issue #${issueNumber}`, statusCode, err);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type OctokitPermissions =
+  | { admin?: boolean; maintain?: boolean; push?: boolean; triage?: boolean; pull?: boolean }
+  | undefined;
+
+function resolveRole(permissions: OctokitPermissions): Contributor['role'] {
+  if (!permissions) return 'contributor';
+  if (permissions.admin) return 'owner';
+  if (permissions.maintain || permissions.push) return 'maintainer';
+  return 'contributor';
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,162 @@
+/**
+ * Shared data models for NEXUS.
+ * All types correspond to the data models in IMPLEMENTATION.md §6.
+ */
+
+// ---------------------------------------------------------------------------
+// Agent
+// ---------------------------------------------------------------------------
+
+/** The type of agent being managed. */
+export type AgentType = 'claude' | 'codex' | 'openclaw';
+
+/** Lifecycle status of an agent session. */
+export type AgentStatus = 'idle' | 'working' | 'error' | 'disconnected';
+
+/** Static configuration for a single agent, as stored in nexus.config.json. */
+export interface AgentConfig {
+  id: string;
+  type: AgentType;
+  workdir?: string;
+  host?: string;
+  port?: number;
+  transport?: 'ssh' | 'websocket';
+  autopr: boolean;
+}
+
+/** Runtime session state for a connected agent. */
+export interface AgentSession extends AgentConfig {
+  status: AgentStatus;
+  currentTask?: string;
+  pid?: number;
+  connectedAt?: Date;
+  lastSeen?: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Git
+// ---------------------------------------------------------------------------
+
+/** Snapshot of the working tree status for a git repository. */
+export interface GitStatus {
+  branch: string;
+  isDirty: boolean;
+  modified: string[];
+  untracked: string[];
+  staged: string[];
+  deleted: string[];
+}
+
+/** A single commit entry from the log. */
+export interface Commit {
+  hash: string;
+  date: string;
+  message: string;
+  author: string;
+}
+
+/** A nested git repository detected within the workspace. */
+export interface SubRepo {
+  name: string;
+  /** Path relative to workspace root. */
+  path: string;
+  remote?: string;
+  branch?: string;
+  isDirty?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Task (maps to GitHub Issue)
+// ---------------------------------------------------------------------------
+
+/** Lifecycle status of a task as it moves through the workflow. */
+export type TaskStatus = 'backlog' | 'assigned' | 'in_progress' | 'review' | 'done';
+
+/** Whether a task assignee is an AI agent or a human contributor. */
+export type AssigneeType = 'agent' | 'human';
+
+/** A task tracked by NEXUS, backed by a GitHub Issue. */
+export interface Task {
+  id: string;
+  issueNumber: number;
+  title: string;
+  body: string;
+  labels: string[];
+  status: TaskStatus;
+  assigneeId?: string;
+  assigneeType?: AssigneeType;
+  /** Which sub-repo this task belongs to. */
+  repoPath: string;
+  prNumber?: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub
+// ---------------------------------------------------------------------------
+
+/** A raw GitHub Issue as returned by the GitHub API. */
+export interface Issue {
+  issueNumber: number;
+  title: string;
+  body: string;
+  labels: string[];
+  assigneeLogin?: string;
+  url: string;
+  state: 'open' | 'closed';
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** The merge/review status of a pull request. */
+export type PRStatus = 'open' | 'closed' | 'merged' | 'draft';
+
+/** A GitHub pull request. */
+export interface PR {
+  prNumber: number;
+  title: string;
+  url: string;
+  status: PRStatus;
+  head: string;
+  base: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Filters for listing GitHub issues. */
+export interface IssueFilters {
+  state?: 'open' | 'closed' | 'all';
+  labels?: string[];
+  assignee?: string;
+}
+
+/** Input required to create a new GitHub issue. */
+export interface CreateIssueInput {
+  title: string;
+  body?: string;
+  labels?: string[];
+  assignees?: string[];
+}
+
+/** Input required to open a pull request. */
+export interface CreatePRInput {
+  title: string;
+  body?: string;
+  head: string;
+  base: string;
+}
+
+// ---------------------------------------------------------------------------
+// Contributor (human)
+// ---------------------------------------------------------------------------
+
+/** A human contributor tracked in the workspace. */
+export interface Contributor {
+  login: string;
+  name?: string;
+  email?: string;
+  avatarUrl?: string;
+  currentTaskId?: string;
+  role: 'owner' | 'maintainer' | 'contributor';
+}

--- a/src/ui/hooks/useGitHubStore.ts
+++ b/src/ui/hooks/useGitHubStore.ts
@@ -1,0 +1,70 @@
+import { create } from 'zustand';
+import { GitHubService } from '../../github/GitHubService.js';
+import { logger } from '../../utils/logger.js';
+import type { Issue, Contributor } from '../../types.js';
+
+/**
+ * Attempts to build a {@link GitHubService} from environment variables.
+ * Returns `null` if required variables are missing so the store can surface
+ * a helpful message to the user instead of crashing.
+ */
+function buildService(): GitHubService | null {
+  const token = process.env['GITHUB_TOKEN'];
+  const owner = process.env['GITHUB_OWNER'];
+  const repo = process.env['GITHUB_REPO'];
+  if (!token || !owner || !repo) return null;
+  return new GitHubService({ token, owner, repo });
+}
+
+// Initialised once per process.
+const githubService = buildService();
+
+interface GitHubStoreState {
+  issues: Issue[];
+  contributors: Contributor[];
+  isLoading: boolean;
+  error: string | null;
+  isConfigured: boolean;
+  /**
+   * Fetches open issues and collaborators, then updates the store.
+   * Silently sets `error` on failure rather than throwing.
+   */
+  refresh(): Promise<void>;
+}
+
+/**
+ * Zustand store for GitHub issues and contributor state shown in the Tasks panel.
+ *
+ * Requires `GITHUB_TOKEN`, `GITHUB_OWNER`, and `GITHUB_REPO` env vars to be set.
+ * When they are missing, `isConfigured` is `false` and `refresh()` is a no-op.
+ */
+export const useGitHubStore = create<GitHubStoreState>((set) => ({
+  issues: [],
+  contributors: [],
+  isLoading: false,
+  error: null,
+  isConfigured: githubService !== null,
+
+  async refresh(): Promise<void> {
+    if (!githubService) {
+      set({
+        error: 'GitHub not configured. Set GITHUB_TOKEN, GITHUB_OWNER, and GITHUB_REPO.',
+      });
+      return;
+    }
+
+    set({ isLoading: true, error: null });
+    try {
+      const [issues, contributors] = await Promise.all([
+        githubService.getIssues({ state: 'open' }),
+        githubService.getCollaborators(),
+      ]);
+      set({ issues, contributors, isLoading: false });
+      logger.debug({ issueCount: issues.length }, 'GitHub store refreshed');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn({ err }, 'GitHub store refresh failed');
+      set({ isLoading: false, error: message });
+    }
+  },
+}));

--- a/src/ui/hooks/useGitStore.ts
+++ b/src/ui/hooks/useGitStore.ts
@@ -1,0 +1,56 @@
+import { create } from 'zustand';
+import { GitService } from '../../git/GitService.js';
+import { logger } from '../../utils/logger.js';
+import type { GitStatus, Commit, SubRepo } from '../../types.js';
+
+// Initialised once per process — safe for the TUI singleton model.
+const gitService = new GitService(process.cwd());
+
+interface GitStoreState {
+  status: GitStatus | null;
+  aheadBehind: { ahead: number; behind: number };
+  recentCommits: Commit[];
+  subRepos: SubRepo[];
+  isLoading: boolean;
+  error: string | null;
+  /**
+   * Fetches the latest git state and updates the store.
+   * Silently sets `error` on failure rather than throwing.
+   */
+  refresh(): Promise<void>;
+}
+
+/**
+ * Zustand store for all git-related state shown in the Git panel.
+ *
+ * Usage inside a component:
+ * ```ts
+ * const { status, aheadBehind, refresh } = useGitStore();
+ * ```
+ */
+export const useGitStore = create<GitStoreState>((set) => ({
+  status: null,
+  aheadBehind: { ahead: 0, behind: 0 },
+  recentCommits: [],
+  subRepos: [],
+  isLoading: false,
+  error: null,
+
+  async refresh(): Promise<void> {
+    set({ isLoading: true, error: null });
+    try {
+      const [status, aheadBehind, recentCommits, subRepos] = await Promise.all([
+        gitService.getStatus(),
+        gitService.getAheadBehind(),
+        gitService.getRecentCommits(10),
+        gitService.detectSubRepos(process.cwd()),
+      ]);
+      set({ status, aheadBehind, recentCommits, subRepos, isLoading: false });
+      logger.debug({ branch: status.branch, isDirty: status.isDirty }, 'Git store refreshed');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn({ err }, 'Git store refresh failed');
+      set({ isLoading: false, error: message });
+    }
+  },
+}));

--- a/src/ui/panels/GitPanel.tsx
+++ b/src/ui/panels/GitPanel.tsx
@@ -1,18 +1,130 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Box, Text } from 'ink';
+import { useGitStore } from '../hooks/useGitStore.js';
+import type { SubRepo } from '../../types.js';
+
+/** Max number of untracked files to list before truncating. */
+const MAX_FILES = 10;
+
+/** Renders one row per file with a coloured status prefix. */
+const FileRow: React.FC<{ prefix: string; file: string; color: string }> = ({
+  prefix,
+  file,
+  color,
+}) => (
+  <Box>
+    <Text color={color}> {prefix} </Text>
+    <Text>{file}</Text>
+  </Box>
+);
+
+/** Renders a single sub-repo row with dirty indicator and branch. */
+const SubRepoRow: React.FC<{ repo: SubRepo }> = ({ repo }) => (
+  <Box>
+    <Text color={repo.isDirty === true ? 'yellow' : 'green'}>
+      {repo.isDirty === true ? '●' : '○'}{' '}
+    </Text>
+    <Text>{repo.path}</Text>
+    {repo.branch !== undefined && <Text color="#555555"> [{repo.branch}]</Text>}
+  </Box>
+);
 
 /**
- * Git status panel — placeholder for Phase 0.
- * Will display branch info, dirty files, and sub-repos in Phase 1+.
+ * Git status panel.
+ * Displays current branch, ahead/behind tracking, modified/staged/untracked
+ * files, and any detected sub-repositories.
+ *
+ * Data is loaded from {@link useGitStore} on mount and refreshed every 30 s.
  */
 export const GitPanel: React.FC = () => {
+  const { status, aheadBehind, subRepos, isLoading, error, refresh } = useGitStore();
+
+  useEffect(() => {
+    void refresh();
+    const interval = setInterval(() => void refresh(), 30_000);
+    return (): void => clearInterval(interval);
+    // refresh is a stable Zustand action reference — empty deps is intentional.
+  }, []);
+
   return (
     <Box borderStyle="single" flexDirection="column" width="50%" padding={1}>
+      {/* Panel title */}
       <Text color="cyan" bold>
         GIT STATUS
       </Text>
-      <Text color="#555555"> </Text>
-      <Text color="#555555">Loading...</Text>
+
+      {/* Error state */}
+      {error !== null && (
+        <Box marginTop={1}>
+          <Text color="red">{error}</Text>
+        </Box>
+      )}
+
+      {/* Loading placeholder shown only before first data arrives */}
+      {isLoading && status === null && error === null && (
+        <Text color="#555555">Loading...</Text>
+      )}
+
+      {/* Branch + ahead/behind */}
+      {status !== null && (
+        <>
+          <Box marginTop={1} flexDirection="row">
+            <Text color={status.isDirty ? 'yellow' : 'green'}>
+              {status.isDirty ? '●' : '○'}{' '}
+            </Text>
+            <Text bold>{status.branch}</Text>
+            {(aheadBehind.ahead > 0 || aheadBehind.behind > 0) && (
+              <Text color="#555555">
+                {' '}
+                (↑{aheadBehind.ahead} ↓{aheadBehind.behind})
+              </Text>
+            )}
+          </Box>
+
+          {/* Staged files */}
+          {status.staged.map((f) => (
+            <FileRow key={`A:${f}`} prefix="A" file={f} color="green" />
+          ))}
+
+          {/* Modified files */}
+          {status.modified.map((f) => (
+            <FileRow key={`M:${f}`} prefix="M" file={f} color="yellow" />
+          ))}
+
+          {/* Deleted files */}
+          {status.deleted.map((f) => (
+            <FileRow key={`D:${f}`} prefix="D" file={f} color="red" />
+          ))}
+
+          {/* Untracked files — capped at MAX_FILES */}
+          {status.untracked.slice(0, MAX_FILES).map((f) => (
+            <FileRow key={`?:${f}`} prefix="?" file={f} color="#555555" />
+          ))}
+          {status.untracked.length > MAX_FILES && (
+            <Text color="#555555">
+              {'  '}…{status.untracked.length - MAX_FILES} more untracked
+            </Text>
+          )}
+
+          {/* Clean working tree */}
+          {!status.isDirty && (
+            <Text color="green"> nothing to commit, working tree clean</Text>
+          )}
+        </>
+      )}
+
+      {/* Sub-repos section */}
+      {subRepos.length > 0 && (
+        <>
+          <Text> </Text>
+          <Text color="cyan" bold>
+            SUBREPOS
+          </Text>
+          {subRepos.map((repo) => (
+            <SubRepoRow key={repo.path} repo={repo} />
+          ))}
+        </>
+      )}
     </Box>
   );
 };

--- a/src/ui/panels/TasksPanel.tsx
+++ b/src/ui/panels/TasksPanel.tsx
@@ -1,18 +1,100 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Box, Text } from 'ink';
+import { useGitHubStore } from '../hooks/useGitHubStore.js';
+import type { Issue } from '../../types.js';
+
+/** Max issues to display before truncating. */
+const MAX_ISSUES = 15;
+
+/** Renders a single issue row. */
+const IssueRow: React.FC<{ issue: Issue }> = ({ issue }) => (
+  <Box flexDirection="row" marginTop={1}>
+    {/* Issue number */}
+    <Text color="cyan">#{String(issue.issueNumber).padStart(3, ' ')} </Text>
+
+    {/* Title — truncated to 35 chars to fit the panel */}
+    <Text>
+      {issue.title.length > 35 ? `${issue.title.slice(0, 34)}…` : issue.title.padEnd(35)}
+    </Text>
+
+    {/* Assignee */}
+    <Text color={issue.assigneeLogin !== undefined ? 'green' : '#555555'}>
+      {' '}[{issue.assigneeLogin ?? 'unassigned'}]
+    </Text>
+
+    {/* First label */}
+    {issue.labels.length > 0 && (
+      <Text color="magenta"> {issue.labels[0]}</Text>
+    )}
+  </Box>
+);
 
 /**
- * Tasks panel — placeholder for Phase 0.
- * Will display the task queue backed by GitHub Issues in Phase 4+.
+ * Tasks / open issues panel.
+ * Displays GitHub Issues fetched via {@link useGitHubStore}, ordered
+ * newest-first. Shows a configuration prompt when GitHub env vars are absent.
+ *
+ * Data is loaded on mount and refreshed every 60 s.
  */
 export const TasksPanel: React.FC = () => {
+  const { issues, isLoading, error, isConfigured, refresh } = useGitHubStore();
+
+  useEffect(() => {
+    void refresh();
+    const interval = setInterval(() => void refresh(), 60_000);
+    return (): void => clearInterval(interval);
+    // refresh is a stable Zustand action reference — empty deps is intentional.
+  }, []);
+
+  const visible = issues.slice(0, MAX_ISSUES);
+
   return (
     <Box borderStyle="single" flexDirection="column" width="50%" padding={1}>
-      <Text color="cyan" bold>
-        TASKS
-      </Text>
-      <Text color="#555555"> </Text>
-      <Text color="#555555">No tasks loaded</Text>
+      {/* Panel title */}
+      <Box flexDirection="row">
+        <Text color="cyan" bold>
+          TASKS
+        </Text>
+        {issues.length > 0 && (
+          <Text color="#555555"> ({issues.length} open)</Text>
+        )}
+      </Box>
+
+      {/* Not configured */}
+      {!isConfigured && error !== null && (
+        <Box marginTop={1} flexDirection="column">
+          <Text color="yellow">GitHub not configured.</Text>
+          <Text color="#555555">Set GITHUB_TOKEN, GITHUB_OWNER, GITHUB_REPO</Text>
+          <Text color="#555555">in .env to enable issue tracking.</Text>
+        </Box>
+      )}
+
+      {/* Error from a configured-but-failing service */}
+      {isConfigured && error !== null && (
+        <Box marginTop={1}>
+          <Text color="red">{error}</Text>
+        </Box>
+      )}
+
+      {/* Loading placeholder */}
+      {isLoading && issues.length === 0 && error === null && (
+        <Text color="#555555">Loading issues...</Text>
+      )}
+
+      {/* Issue list */}
+      {visible.map((issue) => (
+        <IssueRow key={issue.issueNumber} issue={issue} />
+      ))}
+
+      {/* Truncation notice */}
+      {issues.length > MAX_ISSUES && (
+        <Text color="#555555">…{issues.length - MAX_ISSUES} more issues</Text>
+      )}
+
+      {/* Empty state */}
+      {isConfigured && !isLoading && error === null && issues.length === 0 && (
+        <Text color="green"> No open issues</Text>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

- **`src/types.ts`** — All shared data models from IMPLEMENTATION.md §6: `GitStatus`, `Commit`, `SubRepo`, `Issue`, `PR`, `PRStatus`, `Task`, `Contributor`, plus filter and input types for GitHub operations
- **`src/git/GitService.ts`** — Full git service via `simple-git`: `getCurrentBranch`, `getStatus`, `getAheadBehind`, `getRecentCommits`, `detectSubRepos` (3-level walk, skips `node_modules`/`dist`/`.git`), `createBranch`; typed `GitServiceError`
- **`src/github/GitHubService.ts`** — GitHub service via Octokit: `getIssues`, `createIssue`, `createPR`, `getPRStatus`, `getCollaborators`, `addComment`; `GitHubServiceError` with HTTP status code; PR status resolved from `draft`/`merged_at`/`state` fields
- **`src/ui/hooks/useGitStore.ts`** — Zustand store for git state, auto-refreshes every 30 s
- **`src/ui/hooks/useGitHubStore.ts`** — Zustand store for issues and contributors, auto-refreshes every 60 s; gracefully degrades when `GITHUB_*` env vars are absent
- **`GitPanel`** — Live branch + dirty indicator, ahead/behind count, categorised file list (`M`/`A`/`D`/`?` prefixes, capped at 10), sub-repo section
- **`TasksPanel`** — Open issue list (`#num`, title, assignee, first label); configuration prompt when env vars unset
- **`.env.example`** — Added `GITHUB_OWNER` and `GITHUB_REPO`

## Test plan

- [ ] `npm test` — **42 tests pass** (GitService ×16, GitHubService ×20, ConfigLoader ×6); all mocked — no network or filesystem I/O
- [ ] `npm run typecheck` — zero errors
- [ ] `npm run lint` — zero errors
- [ ] `npm start` — GitPanel shows live branch/status; TasksPanel shows "not configured" prompt if `GITHUB_*` not set, or live issues if set

🤖 Generated with [Claude Code](https://claude.com/claude-code)