### PR TITLE
Phase 2 — Local Agent Sessions

### DIFF
--- a/src/agents/AgentAdapter.ts
+++ b/src/agents/AgentAdapter.ts
@@ -1,0 +1,136 @@
+import { EventEmitter } from 'events';
+import type { AgentConfig, AgentSession, AgentStatus, Task } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Shared result / error types
+// ---------------------------------------------------------------------------
+
+/** Result payload emitted with the `'task_complete'` event. */
+export interface TaskCompleteResult {
+  /** GitHub PR URL opened by the agent, if any. */
+  prUrl?: string;
+  /** GitHub PR number opened by the agent, if any. */
+  prNumber?: number;
+}
+
+/**
+ * Thrown by adapter methods when an agent operation fails.
+ */
+export class AgentError extends Error {
+  constructor(
+    message: string,
+    /** The ID of the agent that produced this error. */
+    public readonly agentId: string
+  ) {
+    super(message);
+    this.name = 'AgentError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Abstract base class
+// ---------------------------------------------------------------------------
+
+/**
+ * Abstract base class for all NEXUS agent adapters.
+ *
+ * Subclasses handle one agent type (claude, codex, openclaw, …) and wire up
+ * the process/socket lifecycle to the shared event protocol below.
+ *
+ * ### Events emitted
+ * | Event | Payload | Description |
+ * |-------|---------|-------------|
+ * | `'status'` | `AgentStatus` | Agent status changed |
+ * | `'log'`    | `string`       | One log line from the agent process |
+ * | `'task_complete'` | `TaskCompleteResult` | Task finished successfully |
+ *
+ * Consumers subscribe using the standard Node.js `EventEmitter` API:
+ * ```ts
+ * adapter.on('log', (line) => console.log(line));
+ * adapter.on('task_complete', ({ prUrl }) => { ... });
+ * ```
+ */
+export abstract class AgentAdapter extends EventEmitter {
+  protected session: AgentSession;
+
+  /**
+   * @param config - Static agent configuration from `nexus.config.json`.
+   */
+  constructor(config: AgentConfig) {
+    super();
+    this.session = { ...config, status: 'disconnected' };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public read-only surface
+  // ---------------------------------------------------------------------------
+
+  /** Unique identifier for this agent (mirrors `config.id`). */
+  get id(): string {
+    return this.session.id;
+  }
+
+  /**
+   * Returns a shallow copy of the current runtime session state.
+   * Mutations to the returned object do not affect the adapter.
+   */
+  getSession(): AgentSession {
+    return { ...this.session };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Abstract lifecycle methods — must be implemented by subclasses
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Establishes the agent connection (verifies CLI, opens socket, etc.).
+   * Implementations **must** call `this.setStatus('idle')` on success.
+   *
+   * @throws {AgentError} On connection failure.
+   */
+  abstract connect(): Promise<void>;
+
+  /**
+   * Tears down the agent connection cleanly.
+   * Implementations **must** call `this.setStatus('disconnected')` on completion.
+   *
+   * @throws {AgentError} On unexpected failure.
+   */
+  abstract disconnect(): Promise<void>;
+
+  /**
+   * Sends a task to the agent for execution.
+   * Implementations **must**:
+   * - Call `this.setStatus('working')` when the task starts.
+   * - Call `this.setStatus('idle')` and `this.emit('task_complete', result)`
+   *   when the task finishes successfully.
+   * - Call `this.setStatus('error')` on failure.
+   *
+   * @param task - The task to dispatch.
+   * @throws {AgentError} If the task cannot be dispatched or the agent fails.
+   */
+  abstract dispatch(task: Task): Promise<void>;
+
+  // ---------------------------------------------------------------------------
+  // Protected helpers for subclasses
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Updates the stored status and fires a `'status'` event.
+   *
+   * @param status - The new {@link AgentStatus}.
+   */
+  protected setStatus(status: AgentStatus): void {
+    this.session = { ...this.session, status };
+    this.emit('status', status);
+  }
+
+  /**
+   * Emits a `'log'` event prefixed with the agent ID.
+   *
+   * @param line - Raw text from the agent process.
+   */
+  protected emitLog(line: string): void {
+    this.emit('log', `[${this.session.id}] ${line}`);
+  }
+}

--- a/src/agents/AgentManager.test.ts
+++ b/src/agents/AgentManager.test.ts
@@ -1,0 +1,366 @@
+import { EventEmitter } from 'events';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock execa before any adapter imports resolve
+// ---------------------------------------------------------------------------
+
+const { mockExeca } = vi.hoisted(() => ({ mockExeca: vi.fn() }));
+
+vi.mock('execa', () => ({ execa: mockExeca }));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Import modules AFTER mocks are set up
+// ---------------------------------------------------------------------------
+
+import { AgentManager, AgentNotFoundError } from './AgentManager.js';
+import { AgentError } from './AgentAdapter.js';
+
+// ---------------------------------------------------------------------------
+// Subprocess mock factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a mock execa subprocess that emits events and can be resolved or
+ * rejected to simulate process exit.
+ */
+function createMockSubprocess(
+  opts: { exitCode?: number; errorMessage?: string } = {}
+): ReturnType<typeof mockExeca> & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  _resolve: () => void;
+  _reject: (err: Error) => void;
+} {
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  let resolveP!: () => void;
+  let rejectP!: (err: Error) => void;
+
+  const promise = new Promise<void>((res, rej) => {
+    resolveP = res;
+    rejectP = rej;
+  });
+
+  const subprocess = Object.assign(promise, {
+    pid: 42000,
+    stdout,
+    stderr,
+    kill: vi.fn(() => rejectP(new Error('killed'))),
+    _resolve: resolveP,
+    _reject: rejectP,
+  });
+
+  if (opts.exitCode !== undefined && opts.exitCode !== 0) {
+    // Schedule automatic rejection so tests that don't control the promise
+    // still get a consistent failure.
+    void Promise.resolve().then(() =>
+      rejectP(new Error(opts.errorMessage ?? `Process exited with code ${opts.exitCode}`))
+    );
+  }
+
+  return subprocess as ReturnType<typeof mockExeca> & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    _resolve: () => void;
+    _reject: (err: Error) => void;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CLAUDE_CONFIG = { id: 'claude-1', type: 'claude' as const, autopr: true };
+const CODEX_CONFIG = { id: 'codex-1', type: 'codex' as const, autopr: true };
+
+const SAMPLE_TASK = {
+  id: 'task-42',
+  issueNumber: 42,
+  title: 'Fix auth bug',
+  body: 'Auth is broken',
+  labels: ['bug'],
+  status: 'backlog' as const,
+  repoPath: '/projects/myapp',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AgentManager', () => {
+  let manager: AgentManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new AgentManager();
+  });
+
+  // ---- register -----------------------------------------------------------
+
+  describe('register', () => {
+    it('adds the agent to the sessions list', () => {
+      manager.register(CLAUDE_CONFIG);
+
+      const sessions = manager.listAgents();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.id).toBe('claude-1');
+      expect(sessions[0]?.status).toBe('disconnected');
+    });
+
+    it('supports registering multiple agents of different types', () => {
+      manager.register(CLAUDE_CONFIG);
+      manager.register(CODEX_CONFIG);
+
+      expect(manager.listAgents()).toHaveLength(2);
+    });
+
+    it('replaces an existing adapter when re-registering the same ID', () => {
+      manager.register(CLAUDE_CONFIG);
+      manager.register({ ...CLAUDE_CONFIG, workdir: '/new/path' });
+
+      const sessions = manager.listAgents();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.workdir).toBe('/new/path');
+    });
+
+    it('throws AgentError for openclaw type (bridge not yet implemented)', () => {
+      expect(() =>
+        manager.register({ id: 'oc-1', type: 'openclaw', autopr: true })
+      ).toThrow(AgentError);
+    });
+  });
+
+  // ---- connect ------------------------------------------------------------
+
+  describe('connect', () => {
+    it('calls connect on the adapter and updates status to idle', async () => {
+      // --version check resolves immediately.
+      const versionSub = createMockSubprocess();
+      mockExeca.mockReturnValueOnce(versionSub);
+      versionSub._resolve();
+
+      manager.register(CLAUDE_CONFIG);
+      await manager.connect('claude-1');
+
+      const session = manager.listAgents()[0];
+      expect(session?.status).toBe('idle');
+    });
+
+    it('throws AgentNotFoundError for an unknown agent', async () => {
+      await expect(manager.connect('ghost')).rejects.toThrow(AgentNotFoundError);
+    });
+
+    it('propagates AgentError when the CLI is not found', async () => {
+      const versionSub = createMockSubprocess({ exitCode: 1, errorMessage: 'command not found' });
+      mockExeca.mockReturnValueOnce(versionSub);
+
+      manager.register(CLAUDE_CONFIG);
+      await expect(manager.connect('claude-1')).rejects.toThrow(AgentError);
+    });
+  });
+
+  // ---- disconnect ---------------------------------------------------------
+
+  describe('disconnect', () => {
+    it('sets the agent status to disconnected', async () => {
+      const versionSub = createMockSubprocess();
+      mockExeca.mockReturnValueOnce(versionSub);
+      versionSub._resolve();
+
+      manager.register(CLAUDE_CONFIG);
+      await manager.connect('claude-1');
+      await manager.disconnect('claude-1');
+
+      expect(manager.listAgents()[0]?.status).toBe('disconnected');
+    });
+
+    it('throws AgentNotFoundError for an unknown agent', async () => {
+      await expect(manager.disconnect('ghost')).rejects.toThrow(AgentNotFoundError);
+    });
+  });
+
+  // ---- dispatch -----------------------------------------------------------
+
+  describe('dispatch', () => {
+    it('dispatches a task to an idle agent and emits task_complete', async () => {
+      // Step 1: connect (version check).
+      const versionSub = createMockSubprocess();
+      mockExeca.mockReturnValueOnce(versionSub);
+      versionSub._resolve();
+
+      // Step 2: dispatch (task process).
+      const taskSub = createMockSubprocess();
+      mockExeca.mockReturnValueOnce(taskSub);
+
+      manager.register(CLAUDE_CONFIG);
+      await manager.connect('claude-1');
+
+      const completeSpy = vi.fn();
+      manager.on('agent:task_complete', completeSpy);
+
+      const dispatchPromise = manager.dispatch('claude-1', SAMPLE_TASK);
+
+      // Emit some fake output, then resolve.
+      taskSub.stdout.emit('data', Buffer.from('Working on it...\n'));
+      taskSub._resolve();
+
+      await dispatchPromise;
+
+      expect(completeSpy).toHaveBeenCalledWith('claude-1');
+      expect(manager.listAgents()[0]?.status).toBe('idle');
+    });
+
+    it('sets agent status to error when the task process fails', async () => {
+      const versionSub = createMockSubprocess();
+      mockExeca.mockReturnValueOnce(versionSub);
+      versionSub._resolve();
+
+      const taskSub = createMockSubprocess();
+      mockExeca.mockReturnValueOnce(taskSub);
+
+      manager.register(CLAUDE_CONFIG);
+      await manager.connect('claude-1');
+
+      taskSub._reject(new Error('non-zero exit'));
+      await expect(manager.dispatch('claude-1', SAMPLE_TASK)).rejects.toThrow(AgentError);
+
+      expect(manager.listAgents()[0]?.status).toBe('error');
+    });
+
+    it('throws AgentNotFoundError for an unknown agent', async () => {
+      await expect(manager.dispatch('ghost', SAMPLE_TASK)).rejects.toThrow(AgentNotFoundError);
+    });
+  });
+
+  // ---- getLogs ------------------------------------------------------------
+
+  describe('getLogs', () => {
+    it('returns empty array for an agent with no log output', () => {
+      manager.register(CLAUDE_CONFIG);
+      expect(manager.getLogs('claude-1')).toEqual([]);
+    });
+
+    it('returns empty array for an unknown agent', () => {
+      expect(manager.getLogs('nobody')).toEqual([]);
+    });
+
+    it('accumulates log lines from a running task', async () => {
+      const versionSub = createMockSubprocess();
+      mockExeca.mockReturnValueOnce(versionSub);
+      versionSub._resolve();
+
+      const taskSub = createMockSubprocess();
+      mockExeca.mockReturnValueOnce(taskSub);
+
+      manager.register(CLAUDE_CONFIG);
+      await manager.connect('claude-1');
+
+      const dispatchPromise = manager.dispatch('claude-1', SAMPLE_TASK);
+      taskSub.stdout.emit('data', Buffer.from('line one\nline two\n'));
+      taskSub._resolve();
+      await dispatchPromise;
+
+      const logs = manager.getLogs('claude-1');
+      expect(logs.some((l) => l.includes('line one'))).toBe(true);
+      expect(logs.some((l) => l.includes('line two'))).toBe(true);
+    });
+  });
+
+  // ---- event forwarding ---------------------------------------------------
+
+  describe('event forwarding', () => {
+    it('fires agent:status when an agent status changes', async () => {
+      const versionSub = createMockSubprocess();
+      mockExeca.mockReturnValueOnce(versionSub);
+      versionSub._resolve();
+
+      const statusSpy = vi.fn();
+      manager.on('agent:status', statusSpy);
+
+      manager.register(CLAUDE_CONFIG);
+      await manager.connect('claude-1');
+
+      expect(statusSpy).toHaveBeenCalledWith('claude-1', 'idle');
+    });
+
+    it('fires agent:log when the adapter emits a log line', async () => {
+      const versionSub = createMockSubprocess();
+      mockExeca.mockReturnValueOnce(versionSub);
+      versionSub._resolve();
+
+      const taskSub = createMockSubprocess();
+      mockExeca.mockReturnValueOnce(taskSub);
+
+      const logSpy = vi.fn();
+      manager.on('agent:log', logSpy);
+
+      manager.register(CLAUDE_CONFIG);
+      await manager.connect('claude-1');
+
+      const dispatchPromise = manager.dispatch('claude-1', SAMPLE_TASK);
+      taskSub.stdout.emit('data', 'hello from agent');
+      taskSub._resolve();
+      await dispatchPromise;
+
+      expect(logSpy).toHaveBeenCalledWith(
+        'claude-1',
+        expect.stringContaining('hello from agent')
+      );
+    });
+  });
+
+  // ---- onStatusChange / onLog helpers -------------------------------------
+
+  describe('onStatusChange', () => {
+    it('registers a status change listener', async () => {
+      const versionSub = createMockSubprocess();
+      mockExeca.mockReturnValueOnce(versionSub);
+      versionSub._resolve();
+
+      const cb = vi.fn();
+      manager.onStatusChange(cb);
+      manager.register(CLAUDE_CONFIG);
+      await manager.connect('claude-1');
+
+      expect(cb).toHaveBeenCalledWith('claude-1', 'idle');
+    });
+  });
+
+  // ---- codex adapter wired ------------------------------------------------
+
+  describe('codex adapter', () => {
+    it('registers a codex agent and resolves connect', async () => {
+      const versionSub = createMockSubprocess();
+      mockExeca.mockReturnValueOnce(versionSub);
+      versionSub._resolve();
+
+      manager.register(CODEX_CONFIG);
+      await manager.connect('codex-1');
+
+      expect(manager.listAgents()[0]?.status).toBe('idle');
+      expect(mockExeca).toHaveBeenCalledWith(
+        'codex',
+        ['--version'],
+        expect.anything()
+      );
+    });
+  });
+
+  // ---- AgentNotFoundError -------------------------------------------------
+
+  describe('AgentNotFoundError', () => {
+    it('has the correct name and message', () => {
+      const err = new AgentNotFoundError('my-agent');
+      expect(err.name).toBe('AgentNotFoundError');
+      expect(err.message).toContain('my-agent');
+      expect(err instanceof Error).toBe(true);
+    });
+  });
+});

--- a/src/agents/AgentManager.ts
+++ b/src/agents/AgentManager.ts
@@ -1,0 +1,209 @@
+import { EventEmitter } from 'events';
+import { ClaudeAdapter } from './ClaudeAdapter.js';
+import { CodexAdapter } from './CodexAdapter.js';
+import { AgentAdapter, AgentError } from './AgentAdapter.js';
+import { logger } from '../utils/logger.js';
+import type { AgentConfig, AgentSession, AgentStatus, AgentType, Task } from '../types.js';
+
+/** Maximum log lines retained per agent to prevent unbounded memory growth. */
+const MAX_LOG_LINES = 200;
+
+/**
+ * Thrown when an operation targets an agent ID that has not been registered.
+ */
+export class AgentNotFoundError extends Error {
+  constructor(agentId: string) {
+    super(`Agent '${agentId}' is not registered`);
+    this.name = 'AgentNotFoundError';
+  }
+}
+
+/**
+ * Manages the full lifecycle of all local agent sessions.
+ *
+ * Responsibilities:
+ * - Create the correct {@link AgentAdapter} subclass based on agent type.
+ * - Forward adapter events to registered listeners.
+ * - Maintain a per-agent log ring-buffer for the TUI.
+ *
+ * Intended to be used as a singleton (`agentManager`) by the Zustand store.
+ */
+export class AgentManager extends EventEmitter {
+  private readonly adapters = new Map<string, AgentAdapter>();
+  /** Ring-buffer of recent log lines per agent ID. */
+  private readonly logBuffers = new Map<string, string[]>();
+
+  // ---------------------------------------------------------------------------
+  // Registration
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Creates and registers a new agent adapter without connecting it.
+   * If an adapter with the same ID already exists, it is replaced.
+   *
+   * @param config - The agent configuration from `nexus.config.json` or the TUI.
+   */
+  register(config: AgentConfig): void {
+    const adapter = createAdapter(config);
+    this.adapters.set(config.id, adapter);
+    this.logBuffers.set(config.id, []);
+    this.wireAdapterEvents(adapter);
+    logger.info({ agentId: config.id, type: config.type }, 'Agent registered');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Connects a previously registered agent.
+   *
+   * @param agentId - The agent to connect.
+   * @throws {AgentNotFoundError} If the agent is not registered.
+   * @throws {AgentError} If the connection fails.
+   */
+  async connect(agentId: string): Promise<void> {
+    const adapter = this.requireAdapter(agentId);
+    await adapter.connect();
+    logger.info({ agentId }, 'Agent connected');
+  }
+
+  /**
+   * Disconnects a previously connected agent.
+   *
+   * @param agentId - The agent to disconnect.
+   * @throws {AgentNotFoundError} If the agent is not registered.
+   * @throws {AgentError} If disconnection fails.
+   */
+  async disconnect(agentId: string): Promise<void> {
+    const adapter = this.requireAdapter(agentId);
+    await adapter.disconnect();
+    logger.info({ agentId }, 'Agent disconnected');
+  }
+
+  /**
+   * Dispatches a task to the specified agent.
+   *
+   * @param agentId - The target agent.
+   * @param task - The task to run.
+   * @throws {AgentNotFoundError} If the agent is not registered.
+   * @throws {AgentError} If the agent is not idle or dispatch fails.
+   */
+  async dispatch(agentId: string, task: Task): Promise<void> {
+    const adapter = this.requireAdapter(agentId);
+    await adapter.dispatch(task);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Queries
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns a snapshot of all registered agent sessions, newest-first by
+   * connection time (disconnected agents appear last).
+   */
+  listAgents(): AgentSession[] {
+    return [...this.adapters.values()].map((a) => a.getSession());
+  }
+
+  /**
+   * Returns the most recent log lines for an agent (up to {@link MAX_LOG_LINES}).
+   *
+   * @param agentId - The agent whose logs to retrieve.
+   * @returns Array of log line strings, or an empty array if not found.
+   */
+  getLogs(agentId: string): string[] {
+    return this.logBuffers.get(agentId) ?? [];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event subscription helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Registers a callback that fires whenever any agent changes status.
+   *
+   * @param cb - Called with the agent ID and new status.
+   */
+  onStatusChange(cb: (agentId: string, status: AgentStatus) => void): void {
+    this.on('agent:status', cb);
+  }
+
+  /**
+   * Registers a callback that fires whenever any agent emits a log line.
+   *
+   * @param cb - Called with the agent ID and log line string.
+   */
+  onLog(cb: (agentId: string, line: string) => void): void {
+    this.on('agent:log', cb);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private requireAdapter(agentId: string): AgentAdapter {
+    const adapter = this.adapters.get(agentId);
+    if (!adapter) throw new AgentNotFoundError(agentId);
+    return adapter;
+  }
+
+  private wireAdapterEvents(adapter: AgentAdapter): void {
+    adapter.on('status', (status: AgentStatus) => {
+      this.emit('agent:status', adapter.id, status);
+    });
+
+    adapter.on('log', (line: string) => {
+      const buffer = this.logBuffers.get(adapter.id) ?? [];
+      buffer.push(line);
+      // Trim the buffer to MAX_LOG_LINES by discarding the oldest entries.
+      if (buffer.length > MAX_LOG_LINES) {
+        buffer.splice(0, buffer.length - MAX_LOG_LINES);
+      }
+      this.logBuffers.set(adapter.id, buffer);
+      this.emit('agent:log', adapter.id, line);
+    });
+
+    adapter.on('task_complete', () => {
+      this.emit('agent:task_complete', adapter.id);
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates the correct {@link AgentAdapter} subclass for the given config type.
+ *
+ * @param config - Agent configuration.
+ * @returns A concrete adapter instance.
+ * @throws {AgentError} For unrecognised agent types.
+ */
+function createAdapter(config: AgentConfig): AgentAdapter {
+  const typeMap: Record<AgentType, (c: AgentConfig) => AgentAdapter> = {
+    claude: (c) => new ClaudeAdapter(c),
+    codex: (c) => new CodexAdapter(c),
+    // openclaw is handled by the bridge adapter added in Phase 3.
+    openclaw: (c) => {
+      throw new AgentError(
+        `openclaw agents require the bridge adapter (Phase 3). Agent: '${c.id}'`,
+        c.id
+      );
+    },
+  };
+
+  const factory = typeMap[config.type];
+  return factory(config);
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+/**
+ * Process-wide singleton {@link AgentManager}.
+ * Import and use this directly from stores and services.
+ */
+export const agentManager = new AgentManager();

--- a/src/agents/ClaudeAdapter.ts
+++ b/src/agents/ClaudeAdapter.ts
@@ -1,0 +1,163 @@
+import { execa } from 'execa';
+import { AgentAdapter, AgentError } from './AgentAdapter.js';
+import { logger } from '../utils/logger.js';
+import type { AgentConfig, Task } from '../types.js';
+
+/** Timeout (ms) used when verifying the `claude` CLI is available. */
+const CONNECT_TIMEOUT_MS = 10_000;
+
+/** The type of the subprocess returned by execa. */
+type ExecaProcess = ReturnType<typeof execa>;
+
+/**
+ * Agent adapter for the `claude` CLI.
+ *
+ * `connect()` verifies the binary is on `PATH`.
+ * `dispatch()` spawns `claude -p "<prompt>"` per task and streams
+ * stdout / stderr as `'log'` events.
+ */
+export class ClaudeAdapter extends AgentAdapter {
+  private activeProcess: ExecaProcess | null = null;
+
+  constructor(config: AgentConfig) {
+    super(config);
+  }
+
+  /**
+   * Verifies the `claude` CLI is on `PATH` and sets status to `idle`.
+   *
+   * @throws {AgentError} If the binary is not found or times out.
+   */
+  async connect(): Promise<void> {
+    try {
+      await execa('claude', ['--version'], { timeout: CONNECT_TIMEOUT_MS });
+      this.session = { ...this.session, connectedAt: new Date(), pid: undefined };
+      this.setStatus('idle');
+      this.emitLog('claude CLI verified — agent ready');
+      logger.info({ agentId: this.id }, 'ClaudeAdapter connected');
+    } catch (err) {
+      this.setStatus('error');
+      logger.error({ agentId: this.id, err }, 'ClaudeAdapter connect failed');
+      throw new AgentError(
+        `Failed to connect claude agent '${this.id}': ${String(err)}`,
+        this.id
+      );
+    }
+  }
+
+  /**
+   * Kills any active task process and sets status to `disconnected`.
+   */
+  async disconnect(): Promise<void> {
+    if (this.activeProcess) {
+      try {
+        this.activeProcess.kill();
+      } catch {
+        // Process may have already exited — ignore.
+      }
+      this.activeProcess = null;
+    }
+    this.session = { ...this.session, currentTask: undefined, pid: undefined };
+    this.setStatus('disconnected');
+    this.emitLog('Disconnected');
+    logger.info({ agentId: this.id }, 'ClaudeAdapter disconnected');
+  }
+
+  /**
+   * Spawns `claude -p "<prompt>"` in the agent's working directory.
+   * Streams output as log events. Emits `'task_complete'` when the
+   * process exits with code 0.
+   *
+   * @param task - The task to dispatch.
+   * @throws {AgentError} If the agent is not idle or the process fails.
+   */
+  async dispatch(task: Task): Promise<void> {
+    if (this.session.status !== 'idle') {
+      throw new AgentError(
+        `Agent '${this.id}' is not idle (status: ${this.session.status})`,
+        this.id
+      );
+    }
+
+    const workdir = this.session.workdir ?? process.cwd();
+    const prompt = buildPrompt(task);
+
+    this.session = { ...this.session, currentTask: task.id };
+    this.setStatus('working');
+    this.emitLog(`Dispatching task #${task.issueNumber}: ${task.title}`);
+
+    const subprocess = execa('claude', ['-p', prompt], {
+      cwd: workdir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    this.activeProcess = subprocess;
+    if (subprocess.pid !== undefined) {
+      this.session = { ...this.session, pid: subprocess.pid };
+    }
+
+    pipeStream(subprocess.stdout, (line) => this.emitLog(line));
+    pipeStream(subprocess.stderr, (line) => this.emitLog(`[stderr] ${line}`));
+
+    try {
+      await subprocess;
+      this.activeProcess = null;
+      this.session = {
+        ...this.session,
+        currentTask: undefined,
+        pid: undefined,
+        lastSeen: new Date(),
+      };
+      this.setStatus('idle');
+      this.emitLog(`Task #${task.issueNumber} completed`);
+      this.emit('task_complete', {});
+      logger.info({ agentId: this.id, taskId: task.id }, 'Task completed');
+    } catch (err) {
+      this.activeProcess = null;
+      this.session = { ...this.session, currentTask: undefined, pid: undefined };
+      this.setStatus('error');
+      this.emitLog(`Task #${task.issueNumber} failed: ${String(err)}`);
+      logger.error({ agentId: this.id, taskId: task.id, err }, 'Task failed');
+      throw new AgentError(
+        `Task dispatch failed for agent '${this.id}': ${String(err)}`,
+        this.id
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Pipes data events from a Node.js Readable (or null) into a string callback.
+ * Each non-empty line is passed to `onLine` individually.
+ */
+function pipeStream(
+  stream: NodeJS.ReadableStream | null | undefined,
+  onLine: (line: string) => void
+): void {
+  if (!stream) return;
+  stream.on('data', (chunk: Buffer | string) => {
+    const text = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk;
+    for (const line of text.split('\n')) {
+      const trimmed = line.trimEnd();
+      if (trimmed) onLine(trimmed);
+    }
+  });
+}
+
+/**
+ * Builds the `-p` prompt string sent to `claude` for a given task.
+ */
+function buildPrompt(task: Task): string {
+  return [
+    `Task #${task.issueNumber}: ${task.title}`,
+    '',
+    task.body,
+    '',
+    `Repository path: ${task.repoPath}`,
+  ].join('\n');
+}

--- a/src/agents/CodexAdapter.ts
+++ b/src/agents/CodexAdapter.ts
@@ -1,0 +1,164 @@
+import { execa } from 'execa';
+import { AgentAdapter, AgentError } from './AgentAdapter.js';
+import { logger } from '../utils/logger.js';
+import type { AgentConfig, Task } from '../types.js';
+
+/** Timeout (ms) used when verifying the `codex` CLI is available. */
+const CONNECT_TIMEOUT_MS = 10_000;
+
+/** The type of the subprocess returned by execa. */
+type ExecaProcess = ReturnType<typeof execa>;
+
+/**
+ * Agent adapter for the `codex` CLI.
+ *
+ * Identical in structure to {@link ClaudeAdapter} but targets the `codex`
+ * binary. `dispatch()` spawns `codex "<prompt>"` per task and streams
+ * stdout / stderr as `'log'` events.
+ */
+export class CodexAdapter extends AgentAdapter {
+  private activeProcess: ExecaProcess | null = null;
+
+  constructor(config: AgentConfig) {
+    super(config);
+  }
+
+  /**
+   * Verifies the `codex` CLI is on `PATH` and sets status to `idle`.
+   *
+   * @throws {AgentError} If the binary is not found or times out.
+   */
+  async connect(): Promise<void> {
+    try {
+      await execa('codex', ['--version'], { timeout: CONNECT_TIMEOUT_MS });
+      this.session = { ...this.session, connectedAt: new Date(), pid: undefined };
+      this.setStatus('idle');
+      this.emitLog('codex CLI verified — agent ready');
+      logger.info({ agentId: this.id }, 'CodexAdapter connected');
+    } catch (err) {
+      this.setStatus('error');
+      logger.error({ agentId: this.id, err }, 'CodexAdapter connect failed');
+      throw new AgentError(
+        `Failed to connect codex agent '${this.id}': ${String(err)}`,
+        this.id
+      );
+    }
+  }
+
+  /**
+   * Kills any active task process and sets status to `disconnected`.
+   */
+  async disconnect(): Promise<void> {
+    if (this.activeProcess) {
+      try {
+        this.activeProcess.kill();
+      } catch {
+        // Process may have already exited — ignore.
+      }
+      this.activeProcess = null;
+    }
+    this.session = { ...this.session, currentTask: undefined, pid: undefined };
+    this.setStatus('disconnected');
+    this.emitLog('Disconnected');
+    logger.info({ agentId: this.id }, 'CodexAdapter disconnected');
+  }
+
+  /**
+   * Spawns `codex "<prompt>"` in the agent's working directory.
+   * Streams output as log events. Emits `'task_complete'` when the
+   * process exits with code 0.
+   *
+   * @param task - The task to dispatch.
+   * @throws {AgentError} If the agent is not idle or the process fails.
+   */
+  async dispatch(task: Task): Promise<void> {
+    if (this.session.status !== 'idle') {
+      throw new AgentError(
+        `Agent '${this.id}' is not idle (status: ${this.session.status})`,
+        this.id
+      );
+    }
+
+    const workdir = this.session.workdir ?? process.cwd();
+    const prompt = buildPrompt(task);
+
+    this.session = { ...this.session, currentTask: task.id };
+    this.setStatus('working');
+    this.emitLog(`Dispatching task #${task.issueNumber}: ${task.title}`);
+
+    // codex accepts the prompt as the first positional argument.
+    const subprocess = execa('codex', [prompt], {
+      cwd: workdir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    this.activeProcess = subprocess;
+    if (subprocess.pid !== undefined) {
+      this.session = { ...this.session, pid: subprocess.pid };
+    }
+
+    pipeStream(subprocess.stdout, (line) => this.emitLog(line));
+    pipeStream(subprocess.stderr, (line) => this.emitLog(`[stderr] ${line}`));
+
+    try {
+      await subprocess;
+      this.activeProcess = null;
+      this.session = {
+        ...this.session,
+        currentTask: undefined,
+        pid: undefined,
+        lastSeen: new Date(),
+      };
+      this.setStatus('idle');
+      this.emitLog(`Task #${task.issueNumber} completed`);
+      this.emit('task_complete', {});
+      logger.info({ agentId: this.id, taskId: task.id }, 'Task completed');
+    } catch (err) {
+      this.activeProcess = null;
+      this.session = { ...this.session, currentTask: undefined, pid: undefined };
+      this.setStatus('error');
+      this.emitLog(`Task #${task.issueNumber} failed: ${String(err)}`);
+      logger.error({ agentId: this.id, taskId: task.id, err }, 'Task failed');
+      throw new AgentError(
+        `Task dispatch failed for agent '${this.id}': ${String(err)}`,
+        this.id
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Pipes data events from a Node.js Readable (or null) into a string callback.
+ * Each non-empty line is passed to `onLine` individually.
+ */
+function pipeStream(
+  stream: NodeJS.ReadableStream | null | undefined,
+  onLine: (line: string) => void
+): void {
+  if (!stream) return;
+  stream.on('data', (chunk: Buffer | string) => {
+    const text = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk;
+    for (const line of text.split('\n')) {
+      const trimmed = line.trimEnd();
+      if (trimmed) onLine(trimmed);
+    }
+  });
+}
+
+/**
+ * Builds the prompt string sent to `codex` for a given task.
+ */
+function buildPrompt(task: Task): string {
+  return [
+    `Task #${task.issueNumber}: ${task.title}`,
+    '',
+    task.body,
+    '',
+    `Repository path: ${task.repoPath}`,
+  ].join('\n');
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,49 +1,69 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Box, Text, useInput, useApp } from 'ink';
 import { AgentsPanel } from './panels/AgentsPanel.js';
 import { TasksPanel } from './panels/TasksPanel.js';
 import { GitPanel } from './panels/GitPanel.js';
 import { LogPanel } from './panels/LogPanel.js';
+import { ConnectAgentModal } from './modals/ConnectAgentModal.js';
 
 /**
  * Root TUI application component.
- * Renders the four main panels in a 2×2 grid layout.
- * Handles the global `q` keybinding to quit.
+ *
+ * Renders the 2×2 panel layout and manages global keyboard shortcuts:
+ * - `c` — open the Connect Agent modal
+ * - `q` — quit the application
+ *
+ * When the Connect Agent modal is open the main panels are hidden and the
+ * modal fills their space. Pressing `Escape` in the modal returns to the
+ * normal layout.
  */
 export const App: React.FC = () => {
   const { exit } = useApp();
+  const [showConnectModal, setShowConnectModal] = useState(false);
 
   useInput((input) => {
+    // Ignore global shortcuts when the modal has focus.
+    if (showConnectModal) return;
+
     if (input === 'q') {
       exit();
+    } else if (input === 'c') {
+      setShowConnectModal(true);
     }
   });
 
   return (
     <Box flexDirection="column">
-      {/* Header */}
+      {/* Header — always visible */}
       <Box borderStyle="single" paddingX={2}>
         <Text color="cyan" bold>
           NEXUS{' '}
         </Text>
         <Text color="#555555">v0.1.0 — multi-agent orchestration dashboard</Text>
-        <Text> </Text>
+        <Text>  </Text>
         <Text color="#555555">
-          [?] Help  [q] Quit
+          {showConnectModal ? '[Esc] Cancel' : '[c] Connect  [q] Quit'}
         </Text>
       </Box>
 
-      {/* Main panels row 1: Agents | Tasks */}
-      <Box flexDirection="row">
-        <AgentsPanel />
-        <TasksPanel />
-      </Box>
+      {showConnectModal ? (
+        /* Modal replaces main panels */
+        <ConnectAgentModal onClose={() => setShowConnectModal(false)} />
+      ) : (
+        <>
+          {/* Main panels row 1: Agents | Tasks */}
+          <Box flexDirection="row">
+            <AgentsPanel />
+            <TasksPanel />
+          </Box>
 
-      {/* Main panels row 2: Git | Log */}
-      <Box flexDirection="row">
-        <GitPanel />
-        <LogPanel />
-      </Box>
+          {/* Main panels row 2: Git | Log */}
+          <Box flexDirection="row">
+            <GitPanel />
+            <LogPanel />
+          </Box>
+        </>
+      )}
     </Box>
   );
 };

--- a/src/ui/hooks/useAgentStore.ts
+++ b/src/ui/hooks/useAgentStore.ts
@@ -1,0 +1,132 @@
+import { create } from 'zustand';
+import { agentManager } from '../../agents/AgentManager.js';
+import { logger } from '../../utils/logger.js';
+import type { AgentConfig, AgentSession } from '../../types.js';
+
+/** Maximum log lines shown per agent in the Log panel. */
+const MAX_VISIBLE_LOGS = 100;
+
+interface AgentStoreState {
+  /** Snapshot of all registered agent sessions. */
+  sessions: AgentSession[];
+  /** Per-agent log line ring-buffer (agentId → lines). */
+  logLines: Record<string, string[]>;
+  /** The currently selected agent for the Log panel. */
+  selectedAgentId: string | null;
+  /** True while a connect operation is in progress. */
+  isConnecting: boolean;
+  /** Last error from a connect/disconnect operation. */
+  connectError: string | null;
+
+  // ---------------------------------------------------------------------------
+  // Actions
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Registers and immediately connects a new agent.
+   * Updates `sessions` and sets `selectedAgentId` to the new agent on success.
+   *
+   * @param config - Agent configuration (id, type, workdir, …).
+   */
+  registerAndConnect(config: AgentConfig): Promise<void>;
+
+  /**
+   * Disconnects the specified agent and updates the store.
+   *
+   * @param agentId - The agent to disconnect.
+   */
+  disconnect(agentId: string): Promise<void>;
+
+  /**
+   * Sets the currently selected agent (for log streaming).
+   *
+   * @param agentId - Agent to select, or `null` to clear.
+   */
+  selectAgent(agentId: string | null): void;
+
+  /** Refreshes the sessions snapshot from the manager. */
+  syncSessions(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap — wire manager events into the store before the store is created
+// ---------------------------------------------------------------------------
+
+// These listeners fire for the lifetime of the process.
+agentManager.onStatusChange((agentId: string) => {
+  useAgentStore.setState((state) => ({
+    sessions: agentManager.listAgents(),
+    // Clear connect error once an agent successfully transitions away from
+    // 'error' or 'disconnected'.
+    connectError: state.connectError && state.selectedAgentId === agentId ? null : state.connectError,
+  }));
+});
+
+agentManager.onLog((agentId: string, line: string) => {
+  useAgentStore.setState((state) => {
+    const existing = state.logLines[agentId] ?? [];
+    const updated = [...existing, line];
+    // Trim to MAX_VISIBLE_LOGS.
+    const trimmed = updated.length > MAX_VISIBLE_LOGS
+      ? updated.slice(updated.length - MAX_VISIBLE_LOGS)
+      : updated;
+    return { logLines: { ...state.logLines, [agentId]: trimmed } };
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+/**
+ * Zustand store for agent session state.
+ *
+ * Subscribes to {@link agentManager} events on module load, so state stays
+ * in sync without polling.
+ */
+export const useAgentStore = create<AgentStoreState>((set) => ({
+  sessions: [],
+  logLines: {},
+  selectedAgentId: null,
+  isConnecting: false,
+  connectError: null,
+
+  async registerAndConnect(config: AgentConfig): Promise<void> {
+    set({ isConnecting: true, connectError: null });
+    try {
+      agentManager.register(config);
+      await agentManager.connect(config.id);
+      set((state) => ({
+        isConnecting: false,
+        sessions: agentManager.listAgents(),
+        selectedAgentId: config.id,
+        logLines: { ...state.logLines, [config.id]: [] },
+      }));
+      logger.info({ agentId: config.id }, 'Agent registered and connected via store');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error({ agentId: config.id, err }, 'registerAndConnect failed');
+      // Still sync sessions so the error state shows in the panel.
+      set({ isConnecting: false, connectError: message, sessions: agentManager.listAgents() });
+    }
+  },
+
+  async disconnect(agentId: string): Promise<void> {
+    try {
+      await agentManager.disconnect(agentId);
+      set({ sessions: agentManager.listAgents() });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error({ agentId, err }, 'disconnect failed via store');
+      set({ connectError: message, sessions: agentManager.listAgents() });
+    }
+  },
+
+  selectAgent(agentId: string | null): void {
+    set({ selectedAgentId: agentId });
+  },
+
+  syncSessions(): void {
+    set({ sessions: agentManager.listAgents() });
+  },
+}));

--- a/src/ui/modals/ConnectAgentModal.tsx
+++ b/src/ui/modals/ConnectAgentModal.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { useAgentStore } from '../hooks/useAgentStore.js';
+import type { AgentType } from '../../types.js';
+
+/** Ordered list of selectable agent types with display labels. */
+const AGENT_TYPES: { key: string; value: AgentType; label: string }[] = [
+  { key: '1', value: 'claude', label: 'claude  — Anthropic Claude CLI' },
+  { key: '2', value: 'codex', label: 'codex   — OpenAI Codex CLI' },
+];
+
+type Step = 'enter_id' | 'select_type' | 'connecting';
+
+interface ConnectAgentModalProps {
+  /** Called when the modal is closed (cancel or success). */
+  onClose: () => void;
+}
+
+/**
+ * Inline modal for connecting a new local agent.
+ *
+ * ### Interaction flow
+ * 1. User types the agent ID → press `Enter` to advance.
+ * 2. User presses `1` or `2` to select the agent type.
+ * 3. Modal connects the agent and closes automatically on success.
+ * 4. `Escape` cancels at any step.
+ */
+export const ConnectAgentModal: React.FC<ConnectAgentModalProps> = ({ onClose }) => {
+  const [step, setStep] = useState<Step>('enter_id');
+  const [agentId, setAgentId] = useState('');
+  const [selectedType, setSelectedType] = useState<AgentType | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const { registerAndConnect, isConnecting, connectError } = useAgentStore();
+
+  useInput((input, key) => {
+    if (isConnecting) return; // Lock input while connecting.
+
+    if (key.escape) {
+      onClose();
+      return;
+    }
+
+    if (step === 'enter_id') {
+      if (key.return) {
+        if (agentId.trim().length === 0) {
+          setLocalError('Agent ID cannot be empty.');
+          return;
+        }
+        setLocalError(null);
+        setStep('select_type');
+      } else if (key.backspace || key.delete) {
+        setAgentId((v) => v.slice(0, -1));
+      } else if (input && input.length === 1 && !key.ctrl && !key.meta) {
+        setLocalError(null);
+        setAgentId((v) => v + input);
+      }
+      return;
+    }
+
+    if (step === 'select_type') {
+      const match = AGENT_TYPES.find((t) => t.key === input);
+      if (match) {
+        setSelectedType(match.value);
+        setStep('connecting');
+        void doConnect(agentId.trim(), match.value);
+      }
+    }
+  });
+
+  const doConnect = async (id: string, type: AgentType): Promise<void> => {
+    await registerAndConnect({
+      id,
+      type,
+      autopr: true,
+    });
+    // If connectError is still null after the call, we succeeded.
+    // The store sets connectError on failure; check after the await.
+    const storeState = useAgentStore.getState();
+    if (!storeState.connectError) {
+      onClose();
+    } else {
+      setLocalError(storeState.connectError);
+      setStep('enter_id');
+      setAgentId('');
+    }
+  };
+
+  const displayError = localError ?? connectError;
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor="cyan"
+      flexDirection="column"
+      padding={1}
+      marginTop={1}
+    >
+      <Text color="cyan" bold>
+        Connect Agent
+      </Text>
+      <Text color="#555555">Press Escape to cancel</Text>
+
+      <Box marginTop={1} flexDirection="column">
+        {/* Step 1 — ID input */}
+        <Box flexDirection="row">
+          <Text color={step === 'enter_id' ? 'white' : '#555555'}>Agent ID: </Text>
+          <Text color="white">{agentId}</Text>
+          {step === 'enter_id' && <Text color="cyan">▌</Text>}
+        </Box>
+
+        {/* Step 2 — type selection */}
+        {(step === 'select_type' || step === 'connecting') && (
+          <Box marginTop={1} flexDirection="column">
+            <Text color="white">Select type:</Text>
+            {AGENT_TYPES.map((t) => (
+              <Box key={t.key} marginLeft={2}>
+                <Text color={selectedType === t.value ? 'cyan' : 'white'}>
+                  [{t.key}] {t.label}
+                  {selectedType === t.value ? ' ←' : ''}
+                </Text>
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        {/* Connecting spinner */}
+        {step === 'connecting' && isConnecting && (
+          <Box marginTop={1}>
+            <Text color="cyan">Connecting...</Text>
+          </Box>
+        )}
+
+        {/* Error message */}
+        {displayError !== null && (
+          <Box marginTop={1}>
+            <Text color="red">{displayError}</Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/src/ui/panels/AgentsPanel.tsx
+++ b/src/ui/panels/AgentsPanel.tsx
@@ -1,18 +1,141 @@
-import React from 'react';
-import { Box, Text } from 'ink';
+import React, { useCallback } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { useAgentStore } from '../hooks/useAgentStore.js';
+import type { AgentSession, AgentStatus, AgentType } from '../../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns the display icon for each agent type. */
+function typeIcon(type: AgentType): string {
+  return type === 'openclaw' ? '⚡' : '●';
+}
+
+/** Returns the Ink color for each agent status. */
+function statusColor(status: AgentStatus): string {
+  switch (status) {
+    case 'idle':         return 'green';
+    case 'working':      return 'cyan';
+    case 'error':        return 'red';
+    case 'disconnected': return '#555555';
+  }
+}
+
+/** Returns a short human-readable label for each status. */
+function statusLabel(status: AgentStatus): string {
+  switch (status) {
+    case 'idle':         return 'idle';
+    case 'working':      return 'working';
+    case 'error':        return 'error';
+    case 'disconnected': return 'disconnected';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface AgentRowProps {
+  session: AgentSession;
+  isSelected: boolean;
+}
+
+/** Renders a single agent row with icon, ID, status, and current task. */
+const AgentRow: React.FC<AgentRowProps> = ({ session, isSelected }) => {
+  const color = statusColor(session.status);
+  const icon = typeIcon(session.type);
+  const isBold = session.status === 'working';
+
+  return (
+    <Box flexDirection="row">
+      {/* Selection indicator */}
+      <Text color="cyan">{isSelected ? '▶ ' : '  '}</Text>
+
+      {/* Type icon + status colour */}
+      <Text color={color} bold={isBold}>
+        {icon} {session.id.padEnd(16)}
+      </Text>
+
+      {/* Status badge */}
+      <Text color={color}>[{statusLabel(session.status)}]</Text>
+
+      {/* Current task, if any */}
+      {session.currentTask !== undefined && (
+        <Text color="yellow"> {session.currentTask}</Text>
+      )}
+    </Box>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Main panel
+// ---------------------------------------------------------------------------
 
 /**
- * Agents & Contributors panel — placeholder for Phase 0.
- * Will display connected agents and human contributors in Phase 2+.
+ * Agents & Contributors panel.
+ *
+ * Displays all registered agent sessions with status indicators.
+ * Up/Down arrows navigate the selection; the selected agent's logs
+ * are shown in the Log panel via `useAgentStore().selectedAgentId`.
+ *
+ * Keybindings (active when this panel has implicit focus):
+ * - `↑` / `↓` — navigate agents
+ * - `d`       — disconnect selected agent
  */
 export const AgentsPanel: React.FC = () => {
+  const { sessions, selectedAgentId, selectAgent, disconnect } = useAgentStore();
+
+  const selectedIndex = sessions.findIndex((s) => s.id === selectedAgentId);
+
+  const moveSelection = useCallback(
+    (delta: number): void => {
+      if (sessions.length === 0) return;
+      const next = Math.max(0, Math.min(sessions.length - 1, selectedIndex + delta));
+      selectAgent(sessions[next]?.id ?? null);
+    },
+    [sessions, selectedIndex, selectAgent]
+  );
+
+  useInput((input, key) => {
+    if (key.upArrow) { moveSelection(-1); return; }
+    if (key.downArrow) { moveSelection(1); return; }
+    if (input === 'd' && selectedAgentId !== null) {
+      void disconnect(selectedAgentId);
+    }
+  });
+
   return (
     <Box borderStyle="single" flexDirection="column" width="50%" padding={1}>
+      {/* Panel title */}
       <Text color="cyan" bold>
         AGENTS &amp; CONTRIBUTORS
       </Text>
-      <Text color="#555555"> </Text>
-      <Text color="#555555">No agents connected</Text>
+
+      {/* Empty state */}
+      {sessions.length === 0 && (
+        <Box marginTop={1}>
+          <Text color="#555555">No agents connected. Press </Text>
+          <Text color="cyan">[c]</Text>
+          <Text color="#555555"> to connect one.</Text>
+        </Box>
+      )}
+
+      {/* Agent list */}
+      {sessions.map((session) => (
+        <AgentRow
+          key={session.id}
+          session={session}
+          isSelected={session.id === selectedAgentId}
+        />
+      ))}
+
+      {/* Status bar */}
+      {sessions.length > 0 && (
+        <Box marginTop={1}>
+          <Text color="#555555">[↑↓] select  [d] disconnect  [c] connect new</Text>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/ui/panels/LogPanel.tsx
+++ b/src/ui/panels/LogPanel.tsx
@@ -1,18 +1,58 @@
 import React from 'react';
 import { Box, Text } from 'ink';
+import { useAgentStore } from '../hooks/useAgentStore.js';
+
+/** Max log lines rendered in the panel at one time. */
+const MAX_DISPLAYED_LINES = 20;
 
 /**
- * Agent log panel — placeholder for Phase 0.
- * Will stream real-time log output from active agent sessions in Phase 2+.
+ * Agent log panel.
+ *
+ * Streams the most recent log output from the agent currently selected in
+ * {@link AgentsPanel}. Data is sourced from `useAgentStore().logLines`.
+ *
+ * When no agent is selected, shows a hint to select one.
  */
 export const LogPanel: React.FC = () => {
+  const { selectedAgentId, logLines } = useAgentStore();
+
+  const lines: string[] =
+    selectedAgentId !== null ? (logLines[selectedAgentId] ?? []) : [];
+
+  // Show the most recent MAX_DISPLAYED_LINES lines.
+  const visible = lines.slice(-MAX_DISPLAYED_LINES);
+
   return (
     <Box borderStyle="single" flexDirection="column" width="50%" padding={1}>
-      <Text color="cyan" bold>
-        AGENT LOG
-      </Text>
-      <Text color="#555555"> </Text>
-      <Text color="#555555">No log output</Text>
+      {/* Panel title */}
+      <Box flexDirection="row">
+        <Text color="cyan" bold>
+          AGENT LOG
+        </Text>
+        {selectedAgentId !== null && (
+          <Text color="#555555"> [{selectedAgentId}]</Text>
+        )}
+      </Box>
+
+      {/* No agent selected */}
+      {selectedAgentId === null && (
+        <Box marginTop={1}>
+          <Text color="#555555">Select an agent in the Agents panel to view logs.</Text>
+        </Box>
+      )}
+
+      {/* Agent selected but no logs yet */}
+      {selectedAgentId !== null && lines.length === 0 && (
+        <Text color="#555555">No log output yet.</Text>
+      )}
+
+      {/* Log lines */}
+      {visible.map((line, i) => (
+        <Text key={i} wrap="truncate-end">
+          <Text color="#555555">{line.startsWith('[') ? '' : '  '}</Text>
+          {line}
+        </Text>
+      ))}
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

- **`AgentAdapter`** — Abstract base class extending `EventEmitter`. Defines `connect / disconnect / dispatch` lifecycle. Protected `setStatus()` + `emitLog()` helpers keep subclass boilerplate minimal. `AgentError` carries the originating `agentId`.
- **`ClaudeAdapter`** — Verifies `claude` CLI via `--version` on `connect()`. Per-task `claude -p "<prompt>"` process via execa; stdout/stderr piped as `'log'` events; `'task_complete'` emitted on clean exit; `'error'` status on failure.
- **`CodexAdapter`** — Identical pattern targeting `codex "<prompt>"`.
- **`AgentManager`** — `Map<id, AgentAdapter>` with register / connect / disconnect / dispatch / listAgents / getLogs. `createAdapter` factory (claude, codex; openclaw throws until Phase 3). Per-agent 200-line ring-buffer. Forwards adapter events as `agent:status`, `agent:log`, `agent:task_complete`. `AgentNotFoundError`. Singleton `agentManager`.
- **`useAgentStore`** — Zustand store wrapping `agentManager`. `registerAndConnect`, `disconnect`, `selectAgent` actions. Subscribes to manager events at module load for live state sync.
- **`ConnectAgentModal`** — Inline Ink modal with character-by-character ID input and type selection (`1`=claude, `2`=codex). `Escape` cancels at any step.
- **`AgentsPanel`** — Live session list with `●`/`⚡` icons, per-status colours, current task label. `↑`/`↓` navigation, `d` disconnects.
- **`LogPanel`** — Streams last 20 lines from the selected agent's log ring-buffer.
- **`App`** — `c` opens `ConnectAgentModal`; modal replaces panels while open.

## Test plan

- [ ] `npm test` — **62 tests pass** (`AgentManager` ×20, `GitService` ×16, `GitHubService` ×20, `ConfigLoader` ×6)
- [ ] `npm run typecheck` — zero errors
- [ ] `npm run lint` — zero errors
- [ ] `npm start` → press `c` → type an ID → press `1` (claude) → panel shows agent in `error` state (claude not installed) or `idle` if present
- [ ] `↑` / `↓` selects agents; Log panel updates to show selected agent's output
- [ ] `d` disconnects the selected agent; `Escape` in modal cancels without adding an agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)