### PR TITLE
fix: align docs with current scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to NEXUS are documented in this file.
 
-Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).  
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
@@ -10,21 +10,15 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-- Initial project structure and scaffold
-- TypeScript 5 + Ink v4 TUI framework setup
-- Git integration via simple-git (branch, status, diff, log)
-- GitHub integration via Octokit (issues, PRs, collaborators)
-- Claude Code local agent adapter
-- OpenCodex local agent adapter
-- Remote agent bridge (WebSocket + SSH tunnel) for OpenClaw
-- Task assignment engine with auto-routing rules
-- PR enforcement wrapper — all agent commits go through PRs
-- Sub-repository detection and context switching
-- Human contributor panel with GitHub collaborator sync
-- Keyboard-driven command interface
-- Structured file logging via pino (no stdout pollution)
-- Zod-based config validation with helpful error messages
-- Reconnect logic with exponential backoff for remote agents
+- Initial TypeScript + Ink (React) TUI scaffold
+- Basic panel layout: Agents, Tasks, Git status, Logs
+- Config loader + schema validation for `nexus.config.json`
+- Git service (status, file lists, ahead/behind, best-effort sub-repo detection)
+- GitHub service (Octokit) and Tasks panel support via `GITHUB_*` env vars
+- Local agent session scaffolding for `claude` and `codex` CLIs
+- Vitest test scaffolding for core services
+
+> Note: items like remote agent bridges, intelligent task assignment, and PR enforcement are part of the roadmap but are **not** shipped end-to-end yet.
 
 ---
 
@@ -32,4 +26,4 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 | Version | Date | Notes |
 |---------|------|-------|
-| 1.0.0 | TBD | Initial public release |
+| 0.1.0 | TBD | Initial scaffold release |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,10 @@
 # Contributing to NEXUS
 
-Thank you for your interest in contributing to NEXUS! This document covers how to contribute code, report issues, and work alongside the AI agents that co-develop this project.
+Thanks for contributing! This repo is still in an early scaffold stage, so the most valuable contributions right now are:
+
+- Tightening the developer experience (setup, scripts, docs)
+- Small, test-backed increments to existing services and UI panels
+- Converting “planned” docs into concrete, incremental milestones
 
 ---
 
@@ -13,7 +17,6 @@ Thank you for your interest in contributing to NEXUS! This document covers how t
 5. [Pull Request Guidelines](#5-pull-request-guidelines)
 6. [Working Alongside AI Agents](#6-working-alongside-ai-agents)
 7. [Review Process](#7-review-process)
-8. [Release Process](#8-release-process)
 
 ---
 
@@ -33,87 +36,73 @@ All contributors — human and AI — are expected to:
 
 ### Prerequisites
 
-Ensure you have:
 - Node.js 20+
-- `gh` CLI authenticated (`gh auth login`)
 - `git` configured with your name and email
-- Optional: `claude` CLI or `codex` CLI for running agents locally
+- Optional: `gh` CLI authenticated (`gh auth login`)
+- Optional: `claude` CLI or `codex` CLI for connecting local agents from the TUI
 
 ### Setup
 
 ```bash
-git clone https://github.com/your-org/nexus.git
-cd nexus
+git clone https://github.com/CMDann/agent-command-center.git
+cd agent-command-center
+
 npm install
+
+# Optional: enable GitHub-backed Tasks panel
 cp .env.example .env
-# Edit .env with your GITHUB_TOKEN and optionally NEXUS_BRIDGE_SECRET
+# Edit .env with your GITHUB_TOKEN and repo coordinates
+
 npm start
 ```
 
-### Running Tests
+### Running checks
 
 ```bash
-npm test              # Run all tests
-npm run test:watch    # Watch mode
-npm run coverage      # Coverage report
+npm test              # vitest (one-shot)
+npm run lint          # eslint
+npm run typecheck     # tsc --noEmit
+npm run build         # tsc emit (sanity check)
 ```
 
-### Linting & Type Checking
+### Formatting
 
 ```bash
-npm run lint          # ESLint
-npm run typecheck     # TypeScript strict check
-npm run format        # Prettier auto-format
+npm run format        # prettier --write src
 ```
 
 ---
 
 ## 3. Development Workflow
 
-NEXUS uses a **trunk-based development** model with short-lived feature branches.
+We use short-lived branches off `main`.
 
 ```
-main (protected)
-  └── feat/contributor-panel        ← human feature branch
-  └── nexus/task-42-fix-auth        ← AI agent branch (auto-named)
-  └── fix/bridge-reconnect          ← human bugfix branch
+main
+  └── feat/something-small
+  └── fix/something-broken
+  └── docs/something-unclear
 ```
 
-### Step-by-Step
+### Step-by-step
 
 1. **Find or create an issue** — All work starts with a GitHub issue
-2. **Create a branch** — Follow naming conventions in `CODING_STANDARDS.md`
+2. **Create a branch** — Prefer `feat/…`, `fix/…`, `docs/…`
 3. **Make changes** — Keep commits small and focused
-4. **Test locally** — All tests must pass before opening a PR
-5. **Open a PR** — Reference the issue, fill in the PR template
-6. **Respond to review** — Address all comments before requesting re-review
-7. **Merge** — Squash merge to keep main history clean
+4. **Run checks locally** — `npm run lint && npm run typecheck && npm test`
+5. **Open a PR** — Reference the issue
+6. **Respond to review** — Address comments before requesting re-review
 
 ---
 
 ## 4. Issue Guidelines
 
-### Before Opening an Issue
+### Before opening an issue
 
 - Search existing issues to avoid duplicates
-- If it's a bug, try to reproduce it with minimal steps
-- If it's a feature, check the roadmap in `IMPLEMENTATION_PLAN.md` first
+- If it’s a feature, check the current roadmap in [IMPLEMENTATION.md](./IMPLEMENTATION.md)
 
-### Issue Labels
-
-| Label | Meaning |
-|-------|---------|
-| `bug` | Something is broken |
-| `feat` | New feature request |
-| `docs` | Documentation improvement |
-| `claude` | Suitable for Claude Code agent |
-| `codex` | Suitable for OpenCodex agent |
-| `openclaw` | Suitable for OpenClaw remote agent |
-| `human` | Requires human judgment |
-| `blocked` | Waiting on another issue or external factor |
-| `good first issue` | Low complexity, good for new contributors |
-
-### Writing a Good Issue
+### Writing a good issue
 
 ```markdown
 ## Summary
@@ -122,36 +111,25 @@ One sentence describing the problem or feature.
 ## Context
 Why does this matter? What's the impact?
 
-## Steps to Reproduce (for bugs)
-1. Step 1
-2. Step 2
-3. Observed: ...
-4. Expected: ...
-
 ## Acceptance Criteria
 - [ ] Criterion 1
 - [ ] Criterion 2
 
 ## Notes
-Any additional context, links, or constraints.
+Links, constraints, or references.
 ```
 
 ---
 
 ## 5. Pull Request Guidelines
 
-### PR Title Format
-```
-[Type] Short description (#issueNumber)
-```
-Examples:
-```
-[feat] Add OpenClaw remote agent adapter (#23)
-[fix] Reconnect logic on bridge auth failure (#31)
-[docs] Update configuration reference (#18)
-```
+### PR rules
 
-### PR Body Template
+- **One issue per PR** — don’t bundle unrelated changes
+- **All checks must pass** — lint, typecheck, tests
+- **Keep PRs small** — under ~400 lines of change is ideal
+
+### Helpful PR body
 
 ```markdown
 ## Summary
@@ -163,122 +141,43 @@ What does this PR do?
 - Fixed Z
 
 ## Testing
-How was this tested? What tests were added?
+How was this tested?
 
-## Screenshots / Output
-(Optional) TUI screenshot or relevant log output
-
-Closes #issueNumber
+Fixes #issueNumber
 ```
-
-### PR Rules
-
-- **One issue per PR** — Don't bundle unrelated changes
-- **All CI checks must pass** — lint, typecheck, tests
-- **No direct pushes to `main`** — this branch is protected
-- **Keep PRs small** — under 400 lines of change is ideal
-- **AI agent PRs** are tagged `[NEXUS]` automatically — these follow the same rules
 
 ---
 
 ## 6. Working Alongside AI Agents
 
-NEXUS is partially developed by AI coding agents. Here's what that means for human contributors:
+This project experiments with AI-assisted development.
 
-### Agent-Opened PRs
+Today, that mostly means:
 
-When an agent opens a PR:
-- The PR title will be prefixed with `[NEXUS]`
-- The branch will follow the pattern `nexus/task-{issue}-{slug}`
-- A comment on the original issue will link to the PR
+- Code is written with clear interfaces and tests so an agent can make safe, incremental changes.
+- Issues are written with concrete acceptance criteria.
 
-Human contributors should:
-- Review agent PRs with the same rigour as human PRs
-- Leave specific, actionable review comments (agents can read and act on them)
-- Approve or request changes via GitHub's review system — agents will pick this up
+Planned automation (not guaranteed yet):
 
-### Assigning Work to Agents vs. Humans
+- Agent-opened PR conventions, labels, and routing rules
+- Guardrails that restrict what agents may do without human review
 
-Use labels to signal intent:
-- Add `claude`, `codex`, or `openclaw` to route to that agent type
-- Add `human` for tasks requiring judgment, design decisions, or external communication
-- Untagged issues enter the auto-assignment pool
+When reviewing agent-authored changes:
 
-### Reviewing Agent Work
-
-Agents are good at:
-- Implementing well-specified features with clear acceptance criteria
-- Writing tests for existing code
-- Refactoring with clear before/after expectations
-- Fixing bugs with reproducible steps
-
-Be more careful reviewing agent work that involves:
-- Security-sensitive code (auth, secrets handling)
-- Complex algorithmic decisions
-- UX/interaction design choices
-- Integration with external services
+- Hold them to the same standard as human PRs
+- Prefer review comments that are specific and actionable
 
 ---
 
 ## 7. Review Process
 
-### For Human PRs
 - At least **1 approval** from a maintainer required
-- Author cannot approve their own PR
-- Stale reviews (>7 days with no activity) will be pinged
-
-### For Agent PRs
-- At least **1 human approval** required
-- CI must pass
-- Maintainer may use "auto-merge on approval" for low-risk agent PRs
-
-### Review Etiquette
-
-```
-# ✅ Good review comment
-"This reconnect logic will retry indefinitely if the host is valid but the 
-secret is wrong. Consider adding a max retry count for auth failures specifically 
-(separate from network failures)."
-
-# ❌ Not helpful
-"This looks wrong."
-```
-
-Prefix comments with:
-- **`nit:`** — Minor style preference, not blocking
-- **`question:`** — Genuine question, not necessarily a change request
-- **`blocking:`** — Must be addressed before merge
-- **`suggestion:`** — Optional improvement
+- CI (or local checks) must pass
+- Prefer squash merges for a clean `main` history
 
 ---
 
-## 8. Release Process
+## References
 
-Releases follow [Semantic Versioning](https://semver.org/):
-- **MAJOR** — breaking changes to config format or CLI interface
-- **MINOR** — new features, new agent adapters
-- **PATCH** — bug fixes, performance improvements
-
-### Release Steps
-
-1. Update `CHANGELOG.md` with all changes since last release
-2. Bump version in `package.json`
-3. Open a PR titled `[release] vX.Y.Z`
-4. After merge: tag the commit `vX.Y.Z` on main
-5. GitHub Actions will publish to npm automatically
-
-### CHANGELOG Format
-
-```markdown
-## [1.1.0] — 2026-05-01
-
-### Added
-- SSH tunnel support for remote agent bridge (#45)
-- Contributor detail view in TUI (#52)
-
-### Fixed  
-- Bridge reconnect not triggering after clean disconnect (#48)
-
-### Changed
-- Auto-assignment now prefers agents by workdir match before label match (#50)
-```
+- Coding standards: [CODINGSTANDARDS.md](./CODINGSTANDARDS.md)
+- Implementation / roadmap: [IMPLEMENTATION.md](./IMPLEMENTATION.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # NEXUS
-### Multi-Agent Terminal Orchestration Platform
+### Agent Command Center (early scaffold)
 
 ```
 ███╗   ██╗███████╗██╗  ██╗██╗   ██╗███████╗
@@ -10,20 +10,48 @@
 ╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚══════╝
 ```
 
-**NEXUS** is a terminal-based multi-agent orchestration dashboard that unifies AI coding agents (Claude Code, OpenCodex, OpenClaw), GitHub project management, Git tracking, and human contributor coordination into a single TUI (Terminal User Interface).
+**NEXUS** is a terminal dashboard (Ink/React) intended to coordinate AI coding agents and human contributors.
+
+This repository is currently in an **early scaffold phase**: the TUI layout and core services exist, but many “big vision” features are not wired end-to-end yet.
 
 ---
 
-## Features
+## Current status (reality check)
 
-- 🤖 **Multi-Agent Support** — Connect Claude Code, OpenCodex, and remote OpenClaw agents
-- 🌐 **Remote Agent Connections** — SSH/WebSocket bridge for agents running on separate machines
-- 📋 **GitHub Integration** — Issue creation, PR tracking, TODO management via `gh` CLI
-- 🔀 **Git Tracking** — Local diff, branch, commit, and status monitoring
-- 👥 **Human Contributor Management** — View, assign, and track human contributors alongside agents
-- 📁 **Sub-repository Support** — Manage monorepos and multi-repo workspaces
-- 🎯 **Intelligent Task Assignment** — Route tasks to the right agent or person based on context
-- 🔄 **PR Enforcement** — All agent commits are automatically wrapped in pull requests
+What you can expect **today**:
+
+- A running Ink-based TUI with panels for:
+  - **Git status** (branch + dirty state + file lists)
+  - **Sub-repo detection** (best-effort scan for nested git repos)
+  - **GitHub issues** panel (requires env vars)
+  - **Agents panel** (local agent sessions)
+  - **Log panel**
+- TypeScript project scaffold with lint/typecheck/tests.
+
+What is **planned / in-progress** (not fully implemented or not hooked up):
+
+- Remote agent connections (SSH/WebSocket bridge)
+- Intelligent task routing / assignment policies
+- PR enforcement / “all agent commits go through PRs” automation
+- Rich contributor management beyond basic GitHub collaborator data
+
+If you’re evaluating the project: treat it as a solid starting point and UI skeleton, not a finished orchestration platform.
+
+---
+
+## Implemented features (now)
+
+- **Local agent sessions (WIP)** — connect to local `claude` or `codex` CLIs from the TUI
+- **Git status** — status + staged/modified/untracked lists
+- **GitHub issues panel** — list open issues via Octokit (requires `GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`)
+- **Config loader** — loads `nexus.config.json` with schema validation
+
+## Planned features
+
+- **Remote agents** — OpenClaw agents on other machines via a secure bridge
+- **Task lifecycle automation** — issue → branch → PR → checks → merge workflows
+- **Multi-repo workspaces** — richer sub-repo mapping + context switching
+- **Policy & guardrails** — configurable rules for what agents may do
 
 ---
 
@@ -32,107 +60,52 @@
 | Tool | Version | Purpose |
 |------|---------|---------|
 | Node.js | ≥ 20.x | Runtime |
-| `gh` CLI | ≥ 2.x | GitHub integration |
 | `git` | ≥ 2.x | Version control |
-| `claude` CLI | latest | Claude Code sessions |
-| `codex` CLI | latest | OpenCodex sessions |
-| SSH access | — | Remote OpenClaw agents |
+| (optional) `gh` CLI | ≥ 2.x | Convenience for humans (not required for the running scaffold) |
+| (optional) `claude` CLI | latest | Local Claude agent sessions |
+| (optional) `codex` CLI | latest | Local Codex agent sessions |
 
 ---
 
-## Quick Start
+## Quick start (verifiably runnable)
 
 ```bash
-# Clone the repo
-git clone https://github.com/your-org/nexus.git
-cd nexus
+git clone https://github.com/CMDann/agent-command-center.git
+cd agent-command-center
 
-# Install dependencies
 npm install
 
-# Configure your environment
+# Optional: enable GitHub Tasks panel
 cp .env.example .env
-# Edit .env with your tokens and agent endpoints
+# Set GITHUB_TOKEN, GITHUB_OWNER, GITHUB_REPO in .env
 
-# Launch NEXUS
 npm start
 ```
 
----
+### Notes
 
-## Configuration
-
-NEXUS is configured via `nexus.config.json` in your project root:
-
-```json
-{
-  "workspace": "/path/to/your/project",
-  "github": {
-    "owner": "your-org",
-    "repo": "your-repo"
-  },
-  "agents": [
-    {
-      "id": "claude-local",
-      "type": "claude",
-      "workdir": "./",
-      "autopr": true
-    },
-    {
-      "id": "openclaw-remote",
-      "type": "openclaw",
-      "host": "192.168.1.100",
-      "port": 7777,
-      "transport": "websocket"
-    }
-  ],
-  "subrepos": [
-    { "name": "frontend", "path": "./packages/frontend" },
-    { "name": "api",      "path": "./packages/api" }
-  ]
-}
-```
+- Without the GitHub env vars, the Tasks panel will show a friendly “not configured” message.
+- Without the `claude` / `codex` CLIs installed, you can still run the TUI, but connecting agents will fail.
 
 ---
 
-## Architecture
+## Project layout (current)
 
 ```
-nexus/
-├── src/
-│   ├── ui/              # Blessed/Ink TUI components
-│   ├── agents/          # Agent adapters (claude, codex, openclaw)
-│   ├── bridge/          # SSH/WebSocket remote agent bridge
-│   ├── github/          # gh CLI wrapper + Octokit client
-│   ├── git/             # Local git integration (simple-git)
-│   ├── tasks/           # Task queue and assignment engine
-│   ├── contributors/    # Human contributor registry
-│   └── config/          # Config loader and validator
-├── nexus.config.json    # Project configuration
-├── .env.example         # Environment variable template
-└── docs/                # Extended documentation
+src/
+  agents/       # agent adapters + session manager (local adapters today)
+  config/       # config schema + loader
+  git/          # git service used by the UI
+  github/       # GitHub service (Octokit)
+  ui/           # Ink UI components (panels + modal)
+  utils/        # logger, helpers
 ```
-
----
-
-## Key Concepts
-
-### Agents
-An **Agent** is any autonomous coding entity NEXUS can dispatch tasks to. Agents can be:
-- **Local** — Running on the same machine (Claude Code, OpenCodex)
-- **Remote** — Running on a separate host (OpenClaw via SSH/WebSocket)
-
-### Tasks
-A **Task** maps to a GitHub Issue. NEXUS can auto-generate tasks from natural language, assign them to agents or humans, and track their completion via PR status.
-
-### Sessions
-A **Session** is an active agent process bound to a working directory. Multiple sessions can run concurrently across different directories or subrepos.
 
 ---
 
 ## License
 
-MIT — See [LICENSE.md](./LICENSE.md)
+MIT — see [LICENS.md](./LICENS.md)
 
 ## Contributing
 


### PR DESCRIPTION
Fixes CMDann/agent-command-center#2\n\n### Summary\n- Rewrite README to clearly separate current scaffold vs planned functionality\n- Make setup instructions runnable for the current repo\n- Fix CONTRIBUTING.md references and scripts\n- Update CHANGELOG to reflect only shipped work