### PR TITLE
Phase 7 — Polish & v1.0.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,96 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Unreleased]
+## [1.0.0] — 2026-03-28
+
+First stable release of NEXUS — a multi-agent terminal orchestration dashboard.
 
 ### Added
-- Initial TypeScript + Ink (React) TUI scaffold
-- Basic panel layout: Agents, Tasks, Git status, Logs
-- Config loader + schema validation for `nexus.config.json`
-- Git service (status, file lists, ahead/behind, best-effort sub-repo detection)
-- GitHub service (Octokit) and Tasks panel support via `GITHUB_*` env vars
-- Local agent session scaffolding for `claude` and `codex` CLIs
-- Vitest test scaffolding for core services
 
-> Note: items like remote agent bridges, intelligent task assignment, and PR enforcement are part of the roadmap but are **not** shipped end-to-end yet.
+#### Phase 0 — Scaffold
+- TypeScript 5 + Ink 4 (React) TUI scaffold with `tsx` dev runner
+- ESLint + Prettier + Vitest test harness; CI-friendly `--max-warnings=0`
+- `nexus.config.json` schema with Zod; `ConfigLoader` with cosmiconfig search
+
+#### Phase 1 — Core Services
+- `GitService` (simple-git): status, branch, commits-ahead, sub-repo detection
+- `GitHubService` (Octokit, read-only): list issues, list/get PRs, CI checks status
+- `GitHubWriteService` (Octokit, write): create issues, create PRs, add comments,
+  add/remove issue assignees
+- Two-layer log redaction: Pino field-path `redact` + pattern-based `sanitizeLogObject`
+  covering GitHub PATs, JWTs, Bearer tokens, AWS key IDs, and more
+
+#### Phase 2 — TUI Panels
+- 2×2 dashboard layout: Agents & Contributors, Tasks, Git Status, Agent Log
+- Keyboard navigation (↑/↓), status colour-coding, selection indicators
+- `useAgentStore`, `useTaskStore`, `useGitStore`, `useGitHubStore` Zustand stores
+
+#### Phase 3 — Agent Adapters
+- `AgentAdapter` abstract base with `connect/disconnect/dispatch` lifecycle
+- `ClaudeAdapter` — spawns `claude` CLI subprocess
+- `CodexAdapter` — spawns `codex` CLI subprocess
+- `OpenClawAdapter` — server mode (bridge listener) + client mode (WebSocket/SSH)
+- `AgentManager` singleton managing registration, lifecycle, and log ring-buffer
+
+#### Phase 4 — Remote Bridge
+- `BridgeServer` WebSocket server with HMAC-SHA256 challenge-response auth
+- `BridgeClient` with exponential-backoff reconnect (1 s → 2 → 4 → 8 → 16 s);
+  after 5 failed attempts marks agent `disconnected` with TUI alert
+- SSH tunnel support via `ssh2` (`openSshTunnel`)
+- Token registry: `NEXUS_BRIDGE_TOKENS` (multi-token) + `NEXUS_BRIDGE_SECRET` fallback
+
+#### Phase 5 — PR Enforcement & Sub-repo Support
+- `AgentPRWrapper` decorator: pre-dispatch branch creation, post-complete PR open,
+  issue comment, task transition to `review`
+- `GitService.createBranch / pushBranch / getCommitsAheadOf`
+- Sub-repo detection in `useGitStore`; Tasks panel filtered by active sub-repo
+- New Issue modal: target sub-repo selector for multi-repo workspaces
+
+#### Phase 6 — Human Contributor Management
+- `ContributorRegistry`: fetches GitHub collaborators, 5-min refresh,
+  tracks `currentTaskId` from open issue assignments
+- `useContributorStore` Zustand store subscribing to registry update events
+- Unified Agents & Contributors panel: agents (working→idle→error→disconnected)
+  + contributors (active-task-first), Enter → detail view
+- `AssignTaskModal`: contributors in numbered list; human assignment calls
+  `addAssignee` + posts `👤 Assigned to @{login} via NEXUS` comment
+- `ContributorDetailModal`: profile, role, open assigned issues; `[r]` to refresh
+
+#### Phase 7 — Polish & v1.0.0 Release
+- **Help overlay** (`?` key): full-screen keyboard shortcut reference; dismiss with
+  `Escape` or `?`
+- **Error boundaries**: each panel wrapped in `ErrorBoundary`; a crashing panel shows
+  `[Panel Error — press r to reload]` instead of killing the TUI
+- **Enhanced log sanitization** (`src/utils/sanitize.ts`): pattern-based redaction of
+  GitHub PATs, fine-grained PATs, OAuth tokens, GitLab PATs, JWTs, HTTP Bearer
+  headers, OpenAI-style keys, and AWS access key IDs; integrated into Pino via
+  `formatters.log`
+- **Reconnect UX**: BridgeClient max-retries now marks agent `disconnected` (not
+  `error`) with clear TUI log message and `[c]` reconnect hint
+- **Single-file bundle**: `npm run build` runs `tsc` type-check then `esbuild`
+  to produce `dist/nexus.js` with `#!/usr/bin/env node` shebang; `bin.nexus`
+  in `package.json` enables `npx nexus` / global `npm install -g`
+- Version bumped from 0.1.0 → 1.0.0
+
+### Changed
+- `AgentsPanel` renamed `onAgentSelect` callback pattern; now accepts
+  `onContributorDetail` prop
+- `TasksPanel.onAssign` callback signature extended with `issueNumber`
+- Header hint bar updated to include `[?] Help`
+
+---
+
+## [0.1.0] — Initial scaffold (unreleased)
+
+### Added
+- Initial TypeScript + Ink scaffold; basic panel layout; config loader;
+  Git service; GitHub service; local agent session scaffolding; Vitest setup
 
 ---
 
 ## Version History
 
-| Version | Date | Notes |
-|---------|------|-------|
-| 0.1.0 | TBD | Initial scaffold release |
+| Version | Date       | Notes                     |
+|---------|------------|---------------------------|
+| 1.0.0   | 2026-03-28 | First stable release      |
+| 0.1.0   | —          | Internal scaffold (never released) |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # NEXUS
-### Multi-Agent Terminal Orchestration Platform
+### Multi-Agent Terminal Orchestration Platform — v1.0.0
 
 ```
 ███╗   ██╗███████╗██╗  ██╗██╗   ██╗███████╗
@@ -10,20 +10,55 @@
 ╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚══════╝
 ```
 
-**NEXUS** is a terminal-based multi-agent orchestration dashboard that unifies AI coding agents (Claude Code, OpenCodex, OpenClaw), GitHub project management, Git tracking, and human contributor coordination into a single TUI (Terminal User Interface).
+**NEXUS** is a terminal-based multi-agent orchestration dashboard. It unifies AI coding
+agents (Claude Code, OpenCodex, OpenClaw), GitHub issue management, Git tracking, and
+human contributor coordination into a single keyboard-driven TUI.
+
+---
+
+## Screenshot
+
+```
+┌────────────────────────────────────────────────────────────────────────────────┐
+│ NEXUS v1.0.0 — multi-agent orchestration dashboard   [?] Help  [q] Quit       │
+├──────────────────────────────────┬─────────────────────────────────────────────┤
+│ AGENTS & CONTRIBUTORS            │ TASKS (3)                                   │
+│  agents                          │                                             │
+│▶ ● claude-local     [idle]       │▶ #  7 Fix login timeout    [in_prog] claude │
+│  ● codex-local      [working]    │  #  3 Add dark mode        [assigned] bob   │
+│    issue-12                      │  #  1 Update README        [backlog]        │
+│  contributors                    │                                             │
+│  👤 alice           [owner]      │ [↑↓] select  [a] assign  [Enter] dispatch  │
+│  👤 bob             [contributor]│ [i] new issue                               │
+│    issue-3                       │                                             │
+│ [↑↓] navigate  [d] disconnect    │                                             │
+│ [Enter] detail  [c] connect      │                                             │
+├──────────────────────────────────┼─────────────────────────────────────────────┤
+│ GIT STATUS                       │ AGENT LOG [codex-local]                     │
+│ branch: main                     │ [codex-local] Connected                     │
+│ modified: 2  staged: 1           │ [codex-local] Created branch:               │
+│                                  │   nexus/task-12-fix-login-timeout           │
+│ sub-repos                        │ [codex-local] Pushed branch                 │
+│  ▶ packages/api  [main] dirty    │ [codex-local] Opened PR #34:                │
+│    packages/web  [main]          │   https://github.com/org/repo/pull/34       │
+│                                  │ [codex-local] Task complete                 │
+│ [r] refresh  [s] set context     │                                             │
+└──────────────────────────────────┴─────────────────────────────────────────────┘
+```
 
 ---
 
 ## Features
 
-- 🤖 **Multi-Agent Support** — Connect Claude Code, OpenCodex, and remote OpenClaw agents
-- 🌐 **Remote Agent Connections** — SSH/WebSocket bridge for agents running on separate machines
-- 📋 **GitHub Integration** — Read-only dashboard sync via `GitHubService`, explicit issue/PR/comment mutations via `GitHubWriteService`
-- 🔀 **Git Tracking** — Local diff, branch, commit, and status monitoring
-- 👥 **Human Contributor Management** — View, assign, and track human contributors alongside agents
-- 📁 **Sub-repository Support** — Manage monorepos and multi-repo workspaces
-- 🎯 **Intelligent Task Assignment** — Route tasks to the right agent or person based on context
-- 🔄 **PR Enforcement** — All agent commits are automatically wrapped in pull requests
+- **Multi-agent support** — Connect Claude Code, OpenCodex, and remote OpenClaw agents simultaneously
+- **Remote bridge** — SSH/WebSocket bridge with HMAC-SHA256 challenge-response auth and exponential-backoff reconnect
+- **GitHub integration** — Sync issues as tasks; create issues, PRs, and comments via write service
+- **PR enforcement** — Every agent task automatically results in a feature branch + pull request
+- **Human contributors** — Track GitHub collaborators alongside agents; assign tasks to people with one keypress
+- **Sub-repo support** — Manage monorepos and multi-repo workspaces; filter tasks by sub-repo context
+- **Intelligent assignment** — Label-based and workdir-based auto-assignment rules
+- **Error-resilient TUI** — Each panel is independently error-bounded; a crash reloads only that panel
+- **Secret-safe logging** — Two-layer redaction: field-path + regex patterns for tokens, JWTs, Bearer headers
 
 ---
 
@@ -32,116 +67,75 @@
 | Tool | Version | Purpose |
 |------|---------|---------|
 | Node.js | ≥ 20.x | Runtime |
-| `gh` CLI | ≥ 2.x | GitHub integration |
 | `git` | ≥ 2.x | Version control |
-| `claude` CLI | latest | Claude Code sessions |
-| `codex` CLI | latest | OpenCodex sessions |
-| SSH access | — | Remote OpenClaw agents |
+| `claude` CLI | latest | Claude Code agent sessions |
+| `codex` CLI | latest | OpenCodex agent sessions |
+| SSH / network access | — | Remote OpenClaw agents |
+
+GitHub integration requires a personal access token with `repo` scope set as `GITHUB_TOKEN`.
 
 ---
 
 ## Quick Start
 
 ```bash
-# Clone the repo
-git clone https://github.com/your-org/nexus.git
-cd nexus
-
-# Install dependencies
+# 1. Clone and install
+git clone https://github.com/CMDann/agent-command-center.git
+cd agent-command-center
 npm install
 
-# Configure your environment
+# 2. Configure environment
 cp .env.example .env
-# Edit .env with your GitHub repo coordinates and tokens (never commit .env)
-# Required for the Tasks panel: GITHUB_TOKEN, GITHUB_OWNER, GITHUB_REPO
-# Optional for remote agents/bridge auth: NEXUS_BRIDGE_SECRET
-# Optional explicit config path: NEXUS_CONFIG_PATH
+# Fill in: GITHUB_TOKEN, GITHUB_OWNER, GITHUB_REPO
+# Optional: NEXUS_BRIDGE_SECRET or NEXUS_BRIDGE_TOKENS for remote agents
 
-# Launch NEXUS
+# 3. Create nexus.config.json (see Configuration below)
+
+# 4. Run in development
 npm start
+
+# 5. Or build and run the bundled CLI
+npm run build
+node dist/nexus.js
+# Or after npm install -g: nexus
 ```
 
-### Developer checks
+### Developer commands
 
 ```bash
-npm run lint
-npm run typecheck
-npm test
-npm run build
-npm run smoke
+npm run lint        # ESLint (zero warnings)
+npm run typecheck   # tsc --noEmit (strict type check)
+npm test            # Vitest unit tests
+npm run coverage    # Test coverage report
+npm run build       # tsc type-check + esbuild single-file bundle → dist/nexus.js
+npm run smoke       # Startup smoke test (exits immediately after init)
 ```
-
-### Remote bridge auth (WebSocket)
-
-Remote OpenClaw connections use a challenge-response auth handshake (HMAC-SHA256). The shared secret is **never sent over the wire**, and each connection includes a server challenge + client nonce for basic replay resistance.
-
-Configure one of:
-
-- `NEXUS_BRIDGE_TOKENS` (preferred): comma-separated `tokenId=secret` pairs
-  - Example: `NEXUS_BRIDGE_TOKENS=openclaw-1=supersecret,ci=anothersecret`
-- `NEXUS_BRIDGE_SECRET` (legacy fallback): single shared secret exposed as tokenId `default`
-
-For the current MVP implementation, if a token exists for `agentId` it will be used; otherwise it falls back to `default`.
-
-## Configuration
-
-NEXUS is configured via `nexus.config.json` in your project root:
-
-```json
-{
-  "workspace": "/path/to/your/project",
-  "repos": [
-    { "name": "frontend", "path": "./packages/frontend" },
-    { "name": "api", "path": "./packages/api" }
-  ],
-  "agents": [
-    {
-      "id": "claude-local",
-      "type": "claude",
-      "workdir": "./",
-      "autopr": true
-    },
-    {
-      "id": "openclaw-remote",
-      "type": "openclaw",
-      "host": "192.168.1.100",
-      "port": 7777,
-      "transport": "websocket"
-    }
-  ]
-}
-```
-
-GitHub repository coordinates and authentication are currently provided via environment variables (see `.env.example`). Read operations are intentionally separated from write operations; see [`docs/github-mutations.md`](./docs/github-mutations.md).
 
 ---
 
 ## Configuration
 
-NEXUS is configured via `nexus.config.json` in your project root.
-
-Optionally set `NEXUS_CONFIG_PATH` to load a specific config file (supports `~` and relative paths).
-
+Create `nexus.config.json` in your project root:
 
 ```json
 {
   "workspace": "/path/to/your/project",
   "github": {
     "owner": "your-org",
-    "repo": "your-repo"
+    "repo":  "your-repo"
   },
   "agents": [
     {
-      "id": "claude-local",
-      "type": "claude",
+      "id":      "claude-local",
+      "type":    "claude",
       "workdir": "./",
-      "autopr": true
+      "autopr":  true
     },
     {
-      "id": "openclaw-remote",
-      "type": "openclaw",
-      "host": "192.168.1.100",
-      "port": 7777,
+      "id":        "openclaw-remote",
+      "type":      "openclaw",
+      "host":      "192.168.1.100",
+      "port":      7777,
       "transport": "websocket"
     }
   ],
@@ -152,77 +146,82 @@ Optionally set `NEXUS_CONFIG_PATH` to load a specific config file (supports `~` 
 }
 ```
 
+**Environment variables** (keep secrets out of `nexus.config.json`):
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GITHUB_TOKEN` | Yes (for mutations) | PAT with `repo` scope |
+| `GITHUB_OWNER` | Yes | Repository owner login |
+| `GITHUB_REPO` | Yes | Repository name |
+| `NEXUS_BRIDGE_SECRET` | For remote agents | Shared secret (single-token legacy) |
+| `NEXUS_BRIDGE_TOKENS` | For remote agents | `id=secret,id2=secret2` pairs |
+| `NEXUS_CONFIG_PATH` | No | Override config file location |
+| `LOG_LEVEL` | No | Pino log level (default: `debug`) |
+
 ---
 
-## Remote Bridge Authentication (WebSocket)
+## Keyboard Shortcuts
 
-Remote agents connecting over WebSocket must authenticate **before** any task messages are accepted.
+| Key | Context | Action |
+|-----|---------|--------|
+| `?` | Global | Toggle help overlay |
+| `c` | Global | Connect a new agent |
+| `i` | Global | Create a new GitHub issue |
+| `q` | Global | Quit NEXUS |
+| `↑` / `↓` | Tasks / Agents panels | Navigate list |
+| `a` | Tasks panel | Assign selected task |
+| `Enter` | Tasks panel | Dispatch task to assigned agent |
+| `d` | Agents panel | Disconnect selected agent |
+| `Enter` | Agents panel (contributor) | Open contributor detail |
+| `r` | Git panel | Refresh git status |
+| `s` | Git panel | Set active sub-repo context |
+| `Escape` | Any modal | Close / cancel |
+| `r` | Error panel | Reload crashed panel |
 
-This repo uses a minimal, secure challenge-response handshake:
+---
 
-1. Server → client: `AUTH_CHALLENGE` with a random `challenge` nonce
-2. Client → server: `AUTH` with `{ tokenId, clientNonce, clientTimeMs, signature }`
-3. Server → client: `AUTH_ACK` on success (otherwise closes the socket)
+## Remote Bridge Authentication
 
-The `signature` is an HMAC-SHA256 over:
+Remote OpenClaw agents connect over WebSocket with a challenge-response handshake:
 
-```
-${tokenId}.${challenge}.${clientNonce}.${clientTimeMs}
-```
+1. Server → client: `AUTH_CHALLENGE` with a random nonce
+2. Client → server: `AUTH` with HMAC-SHA256 signature over `tokenId.challenge.clientNonce.clientTimeMs`
+3. Server → client: `AUTH_ACK` on success
 
 The shared secret is **never sent over the wire**.
 
-### Environment variables
-
 Set one of:
-
-- `NEXUS_BRIDGE_TOKENS` (preferred): comma-separated `tokenId=secret` pairs
-  - Example: `NEXUS_BRIDGE_TOKENS=laptop=supersecret,ci=anothersecret`
-- `NEXUS_BRIDGE_SECRET` (legacy fallback): single shared secret
-
-> Do not put these values in `nexus.config.json`. Keep secrets in `.env`.
+- `NEXUS_BRIDGE_TOKENS=laptop=supersecret,ci=anothersecret` (preferred, multi-token)
+- `NEXUS_BRIDGE_SECRET=supersecret` (legacy, single token)
 
 ---
 
 ## Architecture
 
 ```
-nexus/
-├── src/
-│   ├── ui/              # Blessed/Ink TUI components
-│   ├── agents/          # Agent adapters (claude, codex, openclaw)
-│   ├── bridge/          # SSH/WebSocket remote agent bridge
-│   ├── github/          # gh CLI wrapper + Octokit client
-│   ├── git/             # Local git integration (simple-git)
-│   ├── tasks/           # Task queue and assignment engine
-│   ├── contributors/    # Human contributor registry
-│   └── config/          # Config loader and validator
-├── nexus.config.json    # Project configuration
-├── .env.example         # Environment variable template
-└── docs/                # Extended documentation
+src/
+├── agents/        AgentAdapter (base), ClaudeAdapter, CodexAdapter,
+│                  OpenClawAdapter, AgentPRWrapper, AgentManager
+├── bridge/        BridgeServer, BridgeClient, protocol, auth, tokens
+├── config/        ConfigLoader (cosmiconfig + Zod), schema, loadConfig
+├── contributors/  ContributorRegistry (GitHub collaborators + refresh)
+├── git/           GitService (simple-git)
+├── github/        GitHubService (read), GitHubWriteService (write)
+├── tasks/         TaskEngine (queue + assignment rules), TaskSync
+├── types.ts       Shared data models
+├── ui/
+│   ├── App.tsx    Root component, modal state machine, error boundaries
+│   ├── ErrorBoundary.tsx
+│   ├── hooks/     useAgentStore, useTaskStore, useGitStore,
+│   │              useContributorStore, useGitHubStore
+│   ├── modals/    ConnectAgent, AssignTask, NewIssue,
+│   │              ContributorDetail, Help
+│   └── panels/    Agents, Tasks, Git, Log
+└── utils/         logger (pino), sanitize (secret redaction)
 ```
-
----
-
-## Key Concepts
-
-### Agents
-An **Agent** is any autonomous coding entity NEXUS can dispatch tasks to. Agents can be:
-- **Local** — Running on the same machine (Claude Code, OpenCodex)
-- **Remote** — Running on a separate host (OpenClaw via SSH/WebSocket)
-
-### Tasks
-A **Task** is an internal lifecycle model backed by a GitHub Issue. NEXUS maps issue summaries into local task state, tracks assignment/progress/review independently of raw API responses, and stays read-only on the issue sync path.
-
-### Sessions
-A **Session** is an active agent process bound to a working directory. Multiple sessions can run concurrently across different directories or subrepos.
 
 ---
 
 ## License
 
 MIT — See [LICENSE.md](./LICENSE.md)
-
-## Contributing
-
-See [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexus",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexus",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@octokit/rest": "^21.0.0",
         "cosmiconfig": "^9.0.0",
@@ -20,12 +20,16 @@
         "zod": "^3.23.0",
         "zustand": "^5.0.0"
       },
+      "bin": {
+        "nexus": "dist/nexus.js"
+      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/react": "^18.3.0",
         "@types/ssh2": "^1.15.0",
         "@types/ws": "^8.5.0",
         "@vitest/coverage-v8": "^2.1.0",
+        "esbuild": "^0.24.2",
         "eslint": "^10.1.0",
         "prettier": "^3.3.0",
         "tsx": "^4.19.0",
@@ -135,9 +139,9 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
       "cpu": [
         "ppc64"
       ],
@@ -152,9 +156,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
       "cpu": [
         "arm"
       ],
@@ -169,9 +173,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
       "cpu": [
         "arm64"
       ],
@@ -186,9 +190,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
       "cpu": [
         "x64"
       ],
@@ -203,9 +207,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
       "cpu": [
         "arm64"
       ],
@@ -220,9 +224,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
       "cpu": [
         "x64"
       ],
@@ -237,9 +241,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
       "cpu": [
         "arm64"
       ],
@@ -254,9 +258,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
       "cpu": [
         "x64"
       ],
@@ -271,9 +275,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
       "cpu": [
         "arm"
       ],
@@ -288,9 +292,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
       "cpu": [
         "arm64"
       ],
@@ -305,9 +309,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
       "cpu": [
         "ia32"
       ],
@@ -322,9 +326,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
       "cpu": [
         "loong64"
       ],
@@ -339,9 +343,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
       "cpu": [
         "mips64el"
       ],
@@ -356,9 +360,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
       "cpu": [
         "ppc64"
       ],
@@ -373,9 +377,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
       "cpu": [
         "riscv64"
       ],
@@ -390,9 +394,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
       "cpu": [
         "s390x"
       ],
@@ -407,9 +411,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
       "cpu": [
         "x64"
       ],
@@ -424,9 +428,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
       "cpu": [
         "arm64"
       ],
@@ -441,9 +445,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
       "cpu": [
         "x64"
       ],
@@ -458,9 +462,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
       "cpu": [
         "arm64"
       ],
@@ -475,9 +479,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
       "cpu": [
         "x64"
       ],
@@ -509,9 +513,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
       "cpu": [
         "x64"
       ],
@@ -526,9 +530,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
       "cpu": [
         "arm64"
       ],
@@ -543,9 +547,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
       "cpu": [
         "ia32"
       ],
@@ -560,9 +564,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
       "cpu": [
         "x64"
       ],
@@ -2323,9 +2327,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2336,32 +2340,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -4313,6 +4316,473 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
       }
     },
     "node_modules/tweetnacl": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,18 @@
 {
   "name": "nexus",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Terminal dashboard for multi-agent orchestration",
   "type": "module",
+  "bin": {
+    "nexus": "dist/nexus.js"
+  },
   "engines": {
     "node": ">=20.0.0"
   },
   "scripts": {
     "start": "tsx src/index.tsx",
-    "build": "tsc",
-    "smoke": "NEXUS_SMOKE=1 node dist/index.js",
+    "build": "tsc && esbuild src/index.tsx --bundle --platform=node --target=node20 --outfile=dist/nexus.js --banner:js='#!/usr/bin/env node' --external:ssh2 --external:pino --log-level=warning",
+    "smoke": "NEXUS_SMOKE=1 node dist/nexus.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
@@ -37,6 +40,7 @@
     "@types/ssh2": "^1.15.0",
     "@types/ws": "^8.5.0",
     "@vitest/coverage-v8": "^2.1.0",
+    "esbuild": "^0.24.2",
     "eslint": "^10.1.0",
     "prettier": "^3.3.0",
     "tsx": "^4.19.0",

--- a/src/agents/OpenClawAdapter.ts
+++ b/src/agents/OpenClawAdapter.ts
@@ -256,8 +256,19 @@ export class OpenClawAdapter extends AgentAdapter {
     });
 
     this.client.on('error', (err: Error) => {
-      this.setStatus('error');
-      this.emitLog(`Bridge error: ${err.message}`);
+      // When BridgeClient exhausts all reconnect attempts it emits this
+      // specific message. Mark the agent as 'disconnected' (not 'error') so
+      // the TUI shows the expected state and the user can use [c] to reconnect.
+      const isMaxRetries = err.message.includes('max reconnect retries exhausted');
+      if (isMaxRetries) {
+        this.setStatus('disconnected');
+        this.emitLog(
+          `⚠ Reconnect failed after 5 attempts — agent is unreachable. Use [c] to reconnect.`
+        );
+      } else {
+        this.setStatus('error');
+        this.emitLog(`Bridge error: ${err.message}`);
+      }
       logger.error({ agentId: this.id, err }, 'OpenClawAdapter: bridge client error');
     });
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -8,6 +8,8 @@ import { ConnectAgentModal } from './modals/ConnectAgentModal.js';
 import { AssignTaskModal } from './modals/AssignTaskModal.js';
 import { NewIssueModal } from './modals/NewIssueModal.js';
 import { ContributorDetailModal } from './modals/ContributorDetailModal.js';
+import { HelpModal } from './modals/HelpModal.js';
+import { ErrorBoundary } from './ErrorBoundary.js';
 import { useTaskStore } from './hooks/useTaskStore.js';
 
 // ---------------------------------------------------------------------------
@@ -16,6 +18,7 @@ import { useTaskStore } from './hooks/useTaskStore.js';
 
 type ActiveModal =
   | { type: 'none' }
+  | { type: 'help' }
   | { type: 'connect' }
   | { type: 'assign'; taskId: string; taskTitle: string; issueNumber: number }
   | { type: 'newIssue' }
@@ -31,14 +34,18 @@ const NO_MODAL: ActiveModal = { type: 'none' };
  * Root TUI application component.
  *
  * Renders the 2×2 panel layout and manages global keyboard shortcuts:
- * - `c` — open the Connect Agent modal
- * - `i` — open the New Issue modal
- * - `a` — open the Assign Task modal (delegated from TasksPanel)
+ * - `?`     — toggle the keyboard-shortcut help overlay
+ * - `c`     — open the Connect Agent modal
+ * - `i`     — open the New Issue modal
+ * - `a`     — open the Assign Task modal (delegated from TasksPanel)
  * - `Enter` — dispatch the selected assigned task to its agent
- * - `q` — quit the application
+ * - `q`     — quit the application
+ *
+ * Each panel is wrapped in an {@link ErrorBoundary} so a crash in one panel
+ * shows `[Panel Error — press r to reload]` instead of exiting the TUI.
  *
  * When any modal is open the main panels are hidden and the modal fills
- * their space. Pressing `Escape` in any modal returns to the normal layout.
+ * their space. Pressing `Escape` (or `?` for the help modal) closes it.
  */
 export const App: React.FC = () => {
   const { exit } = useApp();
@@ -48,10 +55,13 @@ export const App: React.FC = () => {
   const closeModal = (): void => setModal(NO_MODAL);
 
   useInput((input) => {
-    // Ignore global shortcuts when any modal is open.
+    // The help modal handles its own close key ('?' / Escape).
+    // All other modals intercept input internally.
     if (modal.type !== 'none') return;
 
-    if (input === 'q') {
+    if (input === '?') {
+      setModal({ type: 'help' });
+    } else if (input === 'q') {
       exit();
     } else if (input === 'c') {
       setModal({ type: 'connect' });
@@ -63,11 +73,11 @@ export const App: React.FC = () => {
     // 'a' is handled by TasksPanel and triggers onAssign callback.
   });
 
-  // Hint text shown in the header.
+  // Hint text shown in the header bar.
   const hint =
     modal.type !== 'none'
       ? '[Esc] Cancel'
-      : '[c] Connect  [i] New Issue  [Enter] Dispatch  [q] Quit';
+      : '[?] Help  [c] Connect  [i] Issue  [Enter] Dispatch  [q] Quit';
 
   return (
     <Box flexDirection="column">
@@ -76,10 +86,15 @@ export const App: React.FC = () => {
         <Text color="cyan" bold>
           NEXUS{' '}
         </Text>
-        <Text color="#555555">v0.1.0 — multi-agent orchestration dashboard</Text>
+        <Text color="#555555">v1.0.0 — multi-agent orchestration dashboard</Text>
         <Text>  </Text>
         <Text color="#555555">{hint}</Text>
       </Box>
+
+      {/* Modals — rendered in place of the panels */}
+      {modal.type === 'help' && (
+        <HelpModal onClose={closeModal} />
+      )}
 
       {modal.type === 'connect' && (
         <ConnectAgentModal onClose={closeModal} />
@@ -105,26 +120,35 @@ export const App: React.FC = () => {
         />
       )}
 
+      {/* Main dashboard — shown only when no modal is open */}
       {modal.type === 'none' && (
         <>
-          {/* Main panels row 1: Agents | Tasks */}
+          {/* Row 1: Agents | Tasks */}
           <Box flexDirection="row">
-            <AgentsPanel
-              onContributorDetail={(login) =>
-                setModal({ type: 'contributorDetail', login })
-              }
-            />
-            <TasksPanel
-              onAssign={(taskId, taskTitle, issueNumber) =>
-                setModal({ type: 'assign', taskId, taskTitle, issueNumber })
-              }
-            />
+            <ErrorBoundary label="Agents">
+              <AgentsPanel
+                onContributorDetail={(login) =>
+                  setModal({ type: 'contributorDetail', login })
+                }
+              />
+            </ErrorBoundary>
+            <ErrorBoundary label="Tasks">
+              <TasksPanel
+                onAssign={(taskId, taskTitle, issueNumber) =>
+                  setModal({ type: 'assign', taskId, taskTitle, issueNumber })
+                }
+              />
+            </ErrorBoundary>
           </Box>
 
-          {/* Main panels row 2: Git | Log */}
+          {/* Row 2: Git | Log */}
           <Box flexDirection="row">
-            <GitPanel />
-            <LogPanel />
+            <ErrorBoundary label="Git">
+              <GitPanel />
+            </ErrorBoundary>
+            <ErrorBoundary label="Log">
+              <LogPanel />
+            </ErrorBoundary>
           </Box>
         </>
       )}

--- a/src/ui/ErrorBoundary.tsx
+++ b/src/ui/ErrorBoundary.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Box, Text, useInput } from 'ink';
+
+// ---------------------------------------------------------------------------
+// Fallback component (functional — required to use hooks)
+// ---------------------------------------------------------------------------
+
+interface PanelErrorFallbackProps {
+  /** Panel label shown in the error message. */
+  label: string;
+  /** Called when the user presses `r` to reset the boundary. */
+  onReset: () => void;
+}
+
+/**
+ * Rendered by {@link ErrorBoundary} when the wrapped panel throws.
+ *
+ * Pressing `r` calls `onReset`, clearing the stored error and re-mounting
+ * the original panel children.
+ */
+const PanelErrorFallback: React.FC<PanelErrorFallbackProps> = ({ label, onReset }) => {
+  useInput((input) => {
+    if (input === 'r') onReset();
+  });
+
+  return (
+    <Box borderStyle="single" flexDirection="column" width="50%" padding={1}>
+      <Text color="red" bold>
+        [{label} Error — press r to reload]
+      </Text>
+    </Box>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// ErrorBoundary class component
+// ---------------------------------------------------------------------------
+
+interface ErrorBoundaryProps {
+  /** Short label for the panel (shown in the error message). */
+  label: string;
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Ink-compatible React error boundary.
+ *
+ * Wraps a TUI panel so that a render-time exception shows a recovery prompt
+ * (`[Panel Error — press r to reload]`) instead of crashing the entire TUI.
+ *
+ * ### Usage
+ * ```tsx
+ * <ErrorBoundary label="Tasks">
+ *   <TasksPanel ... />
+ * </ErrorBoundary>
+ * ```
+ */
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  private handleReset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): React.ReactNode {
+    if (this.state.error !== null) {
+      return (
+        <PanelErrorFallback
+          label={this.props.label}
+          onReset={this.handleReset}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/ui/modals/HelpModal.tsx
+++ b/src/ui/modals/HelpModal.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { Box, Text, useInput } from 'ink';
+
+// ---------------------------------------------------------------------------
+// Shortcut data
+// ---------------------------------------------------------------------------
+
+interface ShortcutRow {
+  key: string;
+  description: string;
+}
+
+interface ShortcutSection {
+  section: string;
+  shortcuts: ShortcutRow[];
+}
+
+const SHORTCUTS: ShortcutSection[] = [
+  {
+    section: 'Global',
+    shortcuts: [
+      { key: '?',      description: 'Toggle this help overlay' },
+      { key: 'c',      description: 'Connect a new agent' },
+      { key: 'i',      description: 'Create a new GitHub issue' },
+      { key: 'q',      description: 'Quit NEXUS' },
+    ],
+  },
+  {
+    section: 'Tasks Panel',
+    shortcuts: [
+      { key: '↑ / ↓',  description: 'Navigate task list' },
+      { key: 'a',      description: 'Assign selected task to agent or contributor' },
+      { key: 'Enter',  description: 'Dispatch selected task to its assigned agent' },
+    ],
+  },
+  {
+    section: 'Agents & Contributors Panel',
+    shortcuts: [
+      { key: '↑ / ↓',  description: 'Navigate agents / contributors list' },
+      { key: 'd',      description: 'Disconnect selected agent' },
+      { key: 'Enter',  description: 'Open contributor detail view' },
+    ],
+  },
+  {
+    section: 'Git Panel',
+    shortcuts: [
+      { key: 'r',      description: 'Refresh git status' },
+      { key: 's',      description: 'Set active sub-repo context (filter Tasks panel)' },
+    ],
+  },
+  {
+    section: 'New Issue Modal',
+    shortcuts: [
+      { key: 'Enter',  description: 'Advance to next field / submit' },
+      { key: 'Escape', description: 'Cancel' },
+    ],
+  },
+  {
+    section: 'Contributor Detail Modal',
+    shortcuts: [
+      { key: 'r',      description: 'Refresh assigned issues' },
+      { key: 'Escape', description: 'Close' },
+    ],
+  },
+  {
+    section: 'Any Modal',
+    shortcuts: [
+      { key: 'Escape', description: 'Cancel and return to main panels' },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface HelpModalProps {
+  /** Called when the modal should close. */
+  onClose: () => void;
+}
+
+/**
+ * Full-screen help overlay listing all NEXUS keyboard shortcuts.
+ *
+ * Opened with `?` from the main dashboard. Closed with `Escape` or `?`.
+ */
+export const HelpModal: React.FC<HelpModalProps> = ({ onClose }) => {
+  useInput((input, key) => {
+    if (key.escape || input === '?') {
+      onClose();
+    }
+  });
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor="cyan"
+      flexDirection="column"
+      padding={1}
+      marginTop={1}
+    >
+      <Text color="cyan" bold>
+        NEXUS — Keyboard Shortcuts
+      </Text>
+      <Text color="#555555">Press Escape or ? to close</Text>
+
+      {SHORTCUTS.map(({ section, shortcuts }) => (
+        <Box key={section} flexDirection="column" marginTop={1}>
+          <Text color="white" bold>
+            {section}
+          </Text>
+          {shortcuts.map(({ key, description }) => (
+            <Box key={key} marginLeft={2} flexDirection="row">
+              <Text color="cyan">{key.padEnd(14)}</Text>
+              <Text color="#888888">{description}</Text>
+            </Box>
+          ))}
+        </Box>
+      ))}
+    </Box>
+  );
+};

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,7 @@
 import pino from 'pino';
 import { mkdirSync } from 'fs';
 import { join } from 'path';
+import { sanitizeLogObject } from './sanitize.js';
 
 const LOG_DIR = '.nexus';
 const LOG_FILE = join(LOG_DIR, 'nexus.log');
@@ -14,6 +15,13 @@ mkdirSync(LOG_DIR, { recursive: true });
  * Writes exclusively to `.nexus/nexus.log` — never to stdout — so that
  * log output does not corrupt the Ink TUI render.
  *
+ * ### Secret redaction (two-layer)
+ * 1. **Path-based** (`redact.paths`): pino removes fields whose key matches a
+ *    known secret name (e.g. `token`, `password`).
+ * 2. **Pattern-based** (`formatters.log`): every string value is scanned by
+ *    {@link sanitizeLogObject} and any substring matching a known token format
+ *    (GitHub PATs, JWTs, Bearer headers, etc.) is replaced with `[REDACTED]`.
+ *
  * Usage:
  * ```ts
  * import { logger } from '../utils/logger.js';
@@ -23,10 +31,30 @@ mkdirSync(LOG_DIR, { recursive: true });
 export const logger = pino(
   {
     level: process.env['LOG_LEVEL'] ?? 'debug',
-    // Redact common secret patterns before they reach disk.
+    // Layer 1: redact well-known secret fields by name.
     redact: {
-      paths: ['token', 'secret', 'password', 'authorization'],
+      paths: [
+        'token',
+        'secret',
+        'password',
+        'authorization',
+        'accessToken',
+        'apiKey',
+        'api_key',
+        '*.token',
+        '*.secret',
+        '*.password',
+        '*.authorization',
+        '*.accessToken',
+        '*.apiKey',
+      ],
       censor: '[REDACTED]',
+    },
+    // Layer 2: pattern-based scan of all string values in every log record.
+    formatters: {
+      log(object: Record<string, unknown>): Record<string, unknown> {
+        return sanitizeLogObject(object);
+      },
     },
   },
   pino.destination({ dest: LOG_FILE, sync: false })

--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeString, sanitizeLogObject } from './sanitize.js';
+
+// ---------------------------------------------------------------------------
+// sanitizeString
+// ---------------------------------------------------------------------------
+
+describe('sanitizeString', () => {
+  it('redacts GitHub PATs (ghp_)', () => {
+    const s = 'token=ghp_ABCDEFGHIJKLMNOPQRSTUVWxyz12';
+    expect(sanitizeString(s)).not.toContain('ghp_');
+    expect(sanitizeString(s)).toContain('[REDACTED]');
+  });
+
+  it('redacts GitHub server tokens (ghs_)', () => {
+    const s = 'ghs_1234567890abcdefghijklmnopqrstuv';
+    expect(sanitizeString(s)).not.toContain('ghs_');
+    expect(sanitizeString(s)).toContain('[REDACTED]');
+  });
+
+  it('redacts GitHub fine-grained PATs (github_pat_)', () => {
+    const s = 'auth=github_pat_ABCDEFGHIJKLMNOPQRSTUVWX123456';
+    expect(sanitizeString(s)).not.toContain('github_pat_');
+  });
+
+  it('redacts GitHub OAuth tokens (gho_)', () => {
+    const s = 'gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ123456';
+    expect(sanitizeString(s)).toContain('[REDACTED]');
+  });
+
+  it('redacts HTTP Bearer tokens', () => {
+    const s = 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig';
+    expect(sanitizeString(s)).not.toContain('Bearer eyJ');
+    expect(sanitizeString(s)).toContain('[REDACTED]');
+  });
+
+  it('redacts JWT tokens', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+    expect(sanitizeString(jwt)).not.toMatch(/eyJ/);
+    expect(sanitizeString(jwt)).toContain('[REDACTED]');
+  });
+
+  it('redacts OpenAI-style keys (sk-)', () => {
+    const s = 'key=sk-abcdefghijklmnopqrstuvwxyz12345678';
+    expect(sanitizeString(s)).not.toContain('sk-abc');
+    expect(sanitizeString(s)).toContain('[REDACTED]');
+  });
+
+  it('redacts AWS access key IDs', () => {
+    const s = 'AKIAIOSFODNN7EXAMPLE is an AWS key';
+    expect(sanitizeString(s)).not.toContain('AKIA');
+    expect(sanitizeString(s)).toContain('[REDACTED]');
+  });
+
+  it('leaves plain strings untouched', () => {
+    const s = 'Agent connected to host 192.168.1.1 on port 7777';
+    expect(sanitizeString(s)).toBe(s);
+  });
+
+  it('is idempotent — double-sanitizing does not corrupt the output', () => {
+    const s = 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234';
+    const once = sanitizeString(s);
+    const twice = sanitizeString(once);
+    expect(once).toBe(twice);
+  });
+
+  it('redacts multiple secrets in a single string', () => {
+    const s = 'token1=ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAA token2=ghp_BBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+    const result = sanitizeString(s);
+    expect((result.match(/\[REDACTED\]/g) ?? []).length).toBe(2);
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(sanitizeString('')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeLogObject
+// ---------------------------------------------------------------------------
+
+describe('sanitizeLogObject', () => {
+  it('redacts string values at the top level', () => {
+    const obj = { token: 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ12345' };
+    const result = sanitizeLogObject(obj);
+    expect(result['token']).not.toContain('ghp_');
+    expect(result['token']).toContain('[REDACTED]');
+  });
+
+  it('redacts string values in nested objects', () => {
+    const obj = { auth: { token: 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ12345' } };
+    const result = sanitizeLogObject(obj);
+    expect((result['auth'] as Record<string, unknown>)['token']).toContain('[REDACTED]');
+  });
+
+  it('leaves non-string values unchanged', () => {
+    const obj = { count: 42, flag: true, nothing: null };
+    const result = sanitizeLogObject(obj);
+    expect(result['count']).toBe(42);
+    expect(result['flag']).toBe(true);
+    expect(result['nothing']).toBeNull();
+  });
+
+  it('leaves arrays unchanged', () => {
+    const obj = { tags: ['a', 'b', 'c'] };
+    const result = sanitizeLogObject(obj);
+    expect(result['tags']).toEqual(['a', 'b', 'c']);
+  });
+
+  it('handles empty objects', () => {
+    expect(sanitizeLogObject({})).toEqual({});
+  });
+
+  it('does not mutate the input object', () => {
+    const obj = { token: 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ12345' };
+    sanitizeLogObject(obj);
+    expect(obj['token']).toBe('ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ12345');
+  });
+
+  it('handles circular references gracefully', () => {
+    const obj: Record<string, unknown> = { name: 'test' };
+    obj['self'] = obj; // circular reference
+    expect(() => sanitizeLogObject(obj)).not.toThrow();
+    const result = sanitizeLogObject(obj);
+    expect((result['self'] as Record<string, unknown>)['[circular]']).toBe(true);
+  });
+});

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,85 @@
+/**
+ * Log sanitization utilities.
+ *
+ * Provides pattern-based redaction of secret-like strings before they
+ * reach the log sink, supplementing pino's path-based `redact` option.
+ */
+
+// ---------------------------------------------------------------------------
+// Secret patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * Regex patterns that identify common secret/token formats.
+ * Each pattern targets a specific token type.
+ */
+const SECRET_PATTERNS: ReadonlyArray<RegExp> = [
+  /ghp_[A-Za-z0-9]{20,}/g,                                              // GitHub PATs
+  /ghs_[A-Za-z0-9]{20,}/g,                                              // GitHub server tokens
+  /github_pat_[A-Za-z0-9_]{20,}/g,                                      // GitHub fine-grained PATs
+  /gho_[A-Za-z0-9]{20,}/g,                                              // GitHub OAuth tokens
+  /glpat-[A-Za-z0-9\-_]{20,}/g,                                         // GitLab PATs
+  /Bearer\s+[A-Za-z0-9\-._~+/]+=*/gi,                                   // HTTP Bearer tokens
+  /eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}/g,   // JWT tokens
+  /sk-[A-Za-z0-9]{20,}/g,                                               // OpenAI-style API keys
+  /AKIA[A-Z0-9]{16}/g,                                                  // AWS access key IDs
+];
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Replaces any token/secret-like substring in a string with `[REDACTED]`.
+ *
+ * Patterns cover: GitHub PATs, GitLab PATs, JWT tokens, HTTP Bearer headers,
+ * OpenAI-style keys, and AWS access key IDs.
+ *
+ * @param s - Input string to sanitize.
+ * @returns The sanitized string with secrets replaced.
+ */
+export function sanitizeString(s: string): string {
+  let result = s;
+  for (const pattern of SECRET_PATTERNS) {
+    // Construct a fresh RegExp from the source/flags to reset `lastIndex`
+    // for global patterns used across multiple calls.
+    result = result.replace(new RegExp(pattern.source, pattern.flags), '[REDACTED]');
+  }
+  return result;
+}
+
+/**
+ * Deep-walks a plain log object, applying {@link sanitizeString} to all
+ * string leaves. Non-string leaves (numbers, booleans, null, arrays) are
+ * left unchanged. Cycles in nested objects are skipped gracefully.
+ *
+ * This function is intended to be plugged into pino's `formatters.log` hook
+ * so every structured log entry is sanitized before it reaches the sink.
+ *
+ * @param obj   - The log record to sanitize.
+ * @param _seen - Internal visited-object set used to detect cycles.
+ * @returns A new object with secrets redacted.
+ */
+export function sanitizeLogObject(
+  obj: Record<string, unknown>,
+  _seen: WeakSet<object> = new WeakSet()
+): Record<string, unknown> {
+  if (_seen.has(obj)) return { '[circular]': true };
+  _seen.add(obj);
+
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === 'string') {
+      out[key] = sanitizeString(value);
+    } else if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value)
+    ) {
+      out[key] = sanitizeLogObject(value as Record<string, unknown>, _seen);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Final hardening pass before v1.0.0. All 13 test files pass (192 tests), lint clean, tsc strict clean.

- **Help overlay** — `?` opens a full-screen keyboard shortcut reference; closed with `Escape` or `?` again
- **Error boundaries** — `ErrorBoundary` class component wraps each of the four panels; a render crash shows `[Panel Error — press r to reload]` without killing the TUI
- **Enhanced log sanitization** — `src/utils/sanitize.ts` adds pattern-based redaction (GitHub PATs, JWTs, Bearer tokens, AWS keys, etc.) applied via Pino `formatters.log` on every log record; 19 unit tests
- **Reconnect UX fix** — `OpenClawAdapter` now marks agents `disconnected` (not `error`) after 5 failed reconnect attempts and emits an actionable log line with `[c]` hint
- **Single-file CLI bundle** — `npm run build` runs `tsc` then `esbuild` → `dist/nexus.js` with shebang; `bin.nexus` in package.json enables `npx nexus` / `npm install -g`
- **Version** bumped `0.1.0 → 1.0.0`
- **README** — ASCII TUI screenshot, complete keyboard shortcut table, env var reference, architecture diagram, accurate quick-start
- **CHANGELOG** — v1.0.0 entry covering all 8 phases (Phase 0–7)

## Test plan

- [x] `npm test` — 192 tests, 13 files, all pass
- [x] `npm run lint` — zero warnings
- [x] `npm run typecheck` — zero errors
- [ ] Manual: press `?` to confirm help overlay opens and all bindings are listed
- [ ] Manual: trigger a panel crash to confirm ErrorBoundary shows recovery prompt
- [ ] Manual: `npm run build && node dist/nexus.js` to verify bundled entry works

🤖 Generated with [Claude Code](https://claude.com/claude-code)